### PR TITLE
Improve math appearance

### DIFF
--- a/006-pgo/Makefile
+++ b/006-pgo/Makefile
@@ -93,10 +93,10 @@ preview: $(PAPERBACK).pdf
 
 all: $(PDF) $(SIMUL) $(BIGLIST) testdb testsimul
 
-$(PAPERBACK).pdf: $(TEX) $(MAKEFILE) $(GRAPHS) $(GENTEX) $(PAPERBACK).toc
+$(PAPERBACK).pdf: $(TEX) $(MAKEFILE) $(GRAPHS) $(GENTEX) $(SIMULSRC) $(PAPERBACK).toc testdb
 	$(TEXCC) --shell-escape -jobname=$(basename $(@F)) '\def\paperback{yes}\input{$(<F)}' $(TEXOPTS)
 
-$(PAPERBACK).toc: $(TEX) $(MAKEFILE) $(GRAPHS) $(GENTEX)
+$(PAPERBACK).toc: $(TEX) $(MAKEFILE) $(GRAPHS) $(GENTEX) $(SIMULSRC) testdb
 	$(TEXCC) --shell-escape -jobname=$(basename $(@F)) '\def\paperback{yes}\input{$(<F)}' $(TEXOPTS)
 
 $(BIGLIST): list.tex $(STAT1500TEX) $(STAT2500TEX) $(STATMAXTEX)

--- a/006-pgo/Makefile
+++ b/006-pgo/Makefile
@@ -3,6 +3,7 @@
 .DEFAULT_GOAL:=all
 
 PAPERBACK:=pgo-pb
+HARDBACK:=pgo-hb
 OUT:=out
 TEXCC:=lualatex
 TEXOPTS:=-shell-escape -halt-on-error
@@ -92,6 +93,9 @@ preview: $(PAPERBACK).pdf
 	$(PDFVIEW) $<
 
 all: $(PDF) $(SIMUL) $(BIGLIST) testdb testsimul
+
+$(HARDBACK).pdf: cover-hb.pdf $(PAPERBACK).pdf
+	pdftk $^ cat output $@
 
 $(PAPERBACK).pdf: $(TEX) $(MAKEFILE) $(GRAPHS) $(GENTEX) $(SIMULSRC) $(PAPERBACK).toc testdb
 	$(TEXCC) --shell-escape -jobname=$(basename $(@F)) '\def\paperback{yes}\input{$(<F)}' $(TEXOPTS)
@@ -249,6 +253,7 @@ testsimullong: $(SIMUL)
 
 clean:
 	@rm -vrf $(PAPERBACK).toc $(PAPERBACK).log $(PAPERBACK).aux $(PAPERBACK).lof $(PAPERBACK).listing
+	@rm -vrf $(HARDBACK).pdf
 	@rm -vrf pdfa.xmpi
 	@rm -vrf $(OUT)
 	@rm -vrf svg-inkscape

--- a/006-pgo/attacks.tex
+++ b/006-pgo/attacks.tex
@@ -23,7 +23,7 @@ To calculate the number of typings $E_n$ against which $A$ has some effectivenes
    E_{0} &= R_0 + \binom{R_0}{2} + R_{1}R_{−1}\\
    E_{1} &= R_{1}(R_0 + 1)\\
    E_{2} &= \binom{R_1}{2}\\
-   ARA &= \sum_{n=-3}^{2} \frac{E_{n}1.6^n}{171}
+   \ARA &= \sum_{n=-3}^{2} \frac{E_{n}1.6^n}{171}
 \end{align*}
 under the invariants:
 \begin{align*}
@@ -35,7 +35,7 @@ under the invariants:
   \begin{tabular}{l r r r r|r r r r r r r}
     & \multicolumn{4}{c}{Type → Type} & \multicolumn{6}{c}{Type → Typing} & \\
     & \multicolumn{4}{c}{\raisebox{-4pt}{$\overbrace{\hspace{2cm}}$}} & \multicolumn{6}{c}{\raisebox{-4pt}{$\overbrace{\hspace{4cm}}$}} & \\
-    $A$ & −2 & −1 & 0 & 1 & −3 & −2 & −1 & 0 & 1 & 2 & ARA \\
+    $A$ & −2 & −1 & 0 & 1 & −3 & −2 & −1 & 0 & 1 & 2 & \ARA \\
     \Midrule
 \calign{\includegraphics[height=1em,keepaspectratio]{images/ground.png}} & 1 & 2 & 10 & 5 & 2 & 12 & 27 & 65 & 55 & 10 & 1.173 \\
 \calign{\includegraphics[height=1em,keepaspectratio]{images/rock.png}} & 0 & 3 & 11 & 4 & 0 & 3 & 36 & 78 & 48 & 6 & 1.134 \\
@@ -308,7 +308,7 @@ For each target typing, we can apply the better of the two type relations.
 Two charged attacks of different type have coverage at least as good as,
   and usually much better than, a single type.
 There is no pair of distinct attack types forced into a −3 relation.
-Recall that our best ARA was Ground with 1.173.
+Recall that our best \ARA{} was Ground with 1.173.
 More than 72\% of dual charged attack setups beat this coverage,
  with Ground+Ice posting an outstanding 1.468.
 Only one pair can be forced into a dreaded effectiveness of −3:

--- a/006-pgo/attacks.tex
+++ b/006-pgo/attacks.tex
@@ -71,11 +71,11 @@ If fast attack $A$ is stronger than fast attack $B$ in Nx1 mode, it will not be
   weaker than $B$ in 3x3 mode, and vice versa (i.e.\ partial ordering is maintained).
 Furthermore, no fast attack's Nx1 power is less than its 3x3 power.
 Each Pokémon can store up to 100 units of energy, which is preserved across substitutions.
-PPT and EPT are power and energy, respectively, normalized per turn.
+\PPT{} and \EPT{} are power and energy, respectively, normalized per turn.
 Incinerate is thus the most powerful fast attack in both modes.
-It is also the only five turn attack, and the only one to hit 4 with both EPT and PPT\@.
-Charm stands alone with a PPT of 5, with Razor Leaf coming in behind it at 4.5.
-Lock On manages 5 EPT, with Psycho Cut, Poison Sting, Fairy Wind, Karate Chop,
+It is also the only five turn attack, and the only one to hit 4 with both \EPT{} and \PPT{}\@.
+Charm stands alone with a \PPT{} of 5, with Razor Leaf coming in behind it at 4.5.
+Lock On manages 5 \EPT{}, with Psycho Cut, Poison Sting, Fairy Wind, Karate Chop,
   and Thunder Shock at 4.5.
 Fast attack counts are broken down by type in \autoref{table:attacktypes},
  and \autoref{chap:attackemployers} provides lists of Pokémon which can use each attack.
@@ -87,12 +87,12 @@ The type is persisted across trades, but not across evolution,
 
 \begin{figure}[ht]
 \includegraphics[keepaspectratio,width=\textwidth]{octave/pptvst.png}
-  \caption{PPT vs turns for fast attacks\label{fig:pptvst}}
+  \caption{\PPT{} vs turns for fast attacks\label{fig:pptvst}}
 \end{figure}
 
 \begin{figure}[hb]
 \includegraphics[keepaspectratio,width=\textwidth]{octave/eptvst.png}
-  \caption{EPT vs turns for fast attacks\label{fig:eptvst}}
+  \caption{\EPT{} vs turns for fast attacks\label{fig:eptvst}}
 \end{figure}
 
 \section{Charged Attacks\label{sec:charged}}
@@ -264,8 +264,8 @@ It's sometimes useful to delay use of a charged attack, but is it ever wise to f
   charged attacks entirely?
 Fast attack power ranges from 1 (Locked On) to 20 (Incinerate), but we need look at
   the power per turn (charged attacks operate in a single turn in Trainer Battles).
-Using normalized power, Charm takes the lead with 5 PPT\@.
-Assume STAB and type effectiveness of 2 for Charm, boosting it to 15.36 PPT\@.
+Using normalized power, Charm takes the lead with 5 \PPT{}\@.
+Assume STAB and type effectiveness of 2 for Charm, boosting it to 15.36 \PPT{}\@.
 This is the best case for fast attacks.
 
 Charged attack power ranges from 10 (Frustration) to 170 (Sunsteel Strike).
@@ -289,7 +289,7 @@ Due to charged attacks immediately concluding opponents' fast attacks,
  a fast attack might have knocked out the opponent.
 
 It is true that a charged attack requires energy built up over a number of turns.
-Were these considered, and used to calculate PPT for the charged attack,
+Were these considered, and used to calculate \PPT{} for the charged attack,
   it might well fall below that of the fast attack.
 Such a comparison is invalid; the energy is built up as a result of the fast attack.
 The question is whether the charged attack ought be used, presuming sufficient energy present.

--- a/006-pgo/attacktypes.cpp
+++ b/006-pgo/attacktypes.cpp
@@ -10,7 +10,7 @@
 // gooddpt and goodept are counts of strong moves, vectors of TYPECOUNT size
 void print_latex_table(const unsigned *acounts, const unsigned *gooddpt, const unsigned *goodept){
   printf("\\begin{table}[ht]\\centering\\begin{tabular}{lrrrrrrr}\n");
-  printf("Type & 1 & 2 & 3 & 4 & 5 & PPT>3 & EPT>3\\\\\n");
+  printf("Type & 1 & 2 & 3 & 4 & 5 & \\PPT>3 & \\EPT>3\\\\\n");
   printf("\\Midrule\n");
   for(unsigned e = 0 ; e < TYPECOUNT ; ++e){
     printf("%s", TNames[e]);

--- a/006-pgo/battle.tex
+++ b/006-pgo/battle.tex
@@ -172,7 +172,7 @@ The effect is equivalent to raising the defender's DEF to infinity for the
 $D_A$ is what we can calculate using only the attacker's knowledge, i.e.
  it is that component of $D$ which is independent of the defender.
 
-\[ D_A = P \cdot Eff_A \cdot M_{STAB} \cdot M_B \]
+\[ D_A = P \cdot \mathit{Eff_A} \cdot M_{STAB} \cdot M_B \]
 
 Since this is a product, a proportional increase in any factor leads to
  the same change.
@@ -186,15 +186,15 @@ Increasing power to 12,
  all yield a 20\% increase in $D_A$, 505.3776.
 Note that this is all independent of the opponent.
 
-$D_A$ is divided by $Eff_D$ and scaled by $1.6^T$:
+$D_A$ is divided by $\mathit{Eff_D}$ and scaled by $1.6^T$:
 
-\[ D_D = \frac{D_A}{Eff_D} \cdot 1.6^T \]
+\[ D_D = \frac{D_A}{\mathit{Eff_D}} \cdot 1.6^T \]
 
 We can recover our defined multipliers:
 
-\[ D_D = P \cdot \frac{Eff_A}{Eff_D} \cdot M_C \cdot M_B \]
+\[ D_D = P \cdot \frac{\mathit{Eff_A}}{\mathit{Eff_D}} \cdot M_C \cdot M_B \]
 
-Using the definitions of $Eff_A$ and $Eff_D$, this can be rewritten as:
+Using the definitions of $\mathit{Eff_A}$ and $\mathit{Eff_D}$, this can be rewritten as:
 
 \[ D_D = P \cdot \frac{Mod_A \cdot CPM_A}{Mod_D \cdot CPM_D} \cdot M_C \cdot M_B \]
 
@@ -206,19 +206,19 @@ This is always a positive rational.
 A floor function is applied (ensuring a non-negative integer),
  and one is added (ensuring a positive integer):
 
-\[ D = \left\lfloor P \cdot \frac{Eff_A}{Eff_D} \cdot M_C \cdot M_B \right\rfloor + 1 \]
+\[ D = \left\lfloor P \cdot \frac{\mathit{Eff_A}}{\mathit{Eff_D}} \cdot M_C \cdot M_B \right\rfloor + 1 \]
 
 If $D$ equals or exceeds the opponent's HP, it will fight no more.
 
 \section{Opponent-independent damage}
 We can break the damage equation into those parts dependent upon opponents, and those which are independent.
-Looking at the damage equation, power, $Eff_A$, and STAB do not depend upon an attacker's opponent.
-Likewise $Eff_D$ and MHP for the defender.
-The attacker knows neither $Eff_D$ nor MHP, while the defender doesn't know $Eff_A$.
+Looking at the damage equation, power, $\mathit{Eff_A}$, and STAB do not depend upon an attacker's opponent.
+Likewise $\mathit{Eff_D}$ and MHP for the defender.
+The attacker knows neither $\mathit{Eff_D}$ nor MHP, while the defender doesn't know $\mathit{Eff_A}$.
 Knowing type effectiveness always requires knowing the opposing typing.
 We can thus define an independent core fitness evaluation:
 
-\[ F = Eff_A \cdot P \cdot M_{STAB} \cdot Eff_D \cdot MHP \]
+\[ F = \mathit{Eff_A} \cdot P \cdot M_{STAB} \cdot \mathit{Eff_D} \cdot MHP \]
 
 Note that CPM is implicitly cubed in this function.
 
@@ -233,7 +233,7 @@ As only one fast attack can be known at a time, it's easy enough to define one
 All we need do is normalize the power of the fast attack, using the number of
   Turns it requires.
 
-\[ F = Eff_A \cdot \frac{P_{Fast}}{T_{Fast}} \cdot M_{STAB-Fast} \cdot Eff_D \cdot Eff_S \]
+\[ F = \mathit{Eff_A} \cdot \frac{P_{Fast}}{T_{Fast}} \cdot M_{STAB-Fast} \cdot \mathit{Eff_D} \cdot \mathit{Eff_S} \]
 
 Integrating charged attacks is more complex.
 First, we can simply normalize the charged attack as we did the fast attack,
@@ -336,7 +336,7 @@ Charged attacks cannot be simultaneous; if both Trainers launch a charged attack
   on the same turn, one goes first,and can knock out the opponent before it
   launches its attack.
 The Pokémon that goes first (``Charged Move Priority'') is the one with the
-  higher $Eff_{ARaw}$ (recall that this is base attack plus $IV_A$, times CPM, but does not reflect the Shadow bonus).
+  higher $\mathit{Eff_{ARaw}}$ (recall that this is base attack plus $IV_A$, times CPM, but does not reflect the Shadow bonus).
 Shadow status does not factor into consideration, nor do any active buffs.
 3x3 battles take place four ways: with other Trainers via the friends list,
  with Team Leaders via the Battle screen, the GO Battle League,
@@ -502,7 +502,7 @@ If all six are defeated, their Trainer can optionally continue with another team
 Only one Pokémon of each Trainer is active at a time, but there is unlimited substitution within the team.
 These raids have their own time limits, and the raid ends when the boss is defeated, no more Pokémon remain fighting,
   or the timer (180 seconds for raids below the 5🟉 difficulty level, and 300 seconds otherwise) expires.
-The contest is primarily against this timer, so prioritize Shadow Pokémon and high $Eff_A$.
+The contest is primarily against this timer, so prioritize Shadow Pokémon and high $\mathit{Eff_A}$.
 
 A raid gym has zero or more associated lobbies, each capable of holding twenty Trainers.
 Empty lobbies are immediately destroyed.

--- a/006-pgo/battle.tex
+++ b/006-pgo/battle.tex
@@ -19,7 +19,7 @@ Each attack reduces the opponent's Hit Points by some positive integer.
 This integer is called (inflicted) damage $D$, and calculated as a product of several factors.
 
 \section{The typing multiplier\label{sec:typemult}}
-Determine $M_C$, the common multiplier due typing:
+Determine $M_\mathrm{C}$, the common multiplier due typing:
 
 \[ M_\mathrm{C} = M_\mathrm{STAB} \cdot 1.6^{T} \]
 
@@ -406,7 +406,7 @@ Ahhh, the best part of Pokémon GO: for me, the rest of the game is mindlessly f
 Assemble a team from your Pokémon, and compete with Trainers around the world.
 Battle League operates on three-month seasons, divided into twelve weeks.
 Each week offers participation in two or three formats.
-Most common are the Great League (1500 CP maximum), Ultra League (2500 CP maximum),
+Most common are the Great League (1500 \CP{} maximum), Ultra League (2500 \CP{} maximum),
  and Master League (anything goes).
 There are variations on the Leagues (\textit{Mega} allows Mega evolved Pokémon;
  \textit{Premier} prohibits Legendary and Mythical Pokémon),
@@ -472,11 +472,11 @@ While in the Gym, the Pokémon still counts against the Trainer's storage,
 Berries can be fed to any Pokémon defending a coaligned Gym, though
   each defender can consume only ten berries per thirty minutes.
 Pokémon defending the gym steadily lose \HP{} (``motivation'') at a rate
-  based on their CP (\autoref{sec:cp}).
+  based on their \CP{} (\autoref{sec:cp}).
 The first and second loss both cut 28\% of max motivation, while
   a third loss always knocks the defender out of the gym;
   even a victory cuts 1.6\% of max motivation\footnote{I was unable to personally verify these rates (though they seem plausible); they are taken from the GamePress wiki.}.
-Higher CP results in a more rapid decay of motivation.
+Higher \CP{} results in a more rapid decay of motivation.
 Defenders remain in the Gym until their motivation drops to zero; they cannot be recalled.
 A single Golden Razz berry will fully restore motivation.
 While the gym is controlled by a Raid Boss, the defenders cannot be challenged,
@@ -485,7 +485,7 @@ While the gym is controlled by a Raid Boss, the defenders cannot be challenged,
 Each gym has an associated badge, with Basic, Bronze, Silver and Gold levels.
 The first interaction secures a basic badge.
 Bronze, Silver, and Gold require 500, 4,000, and 30,000 gym points respectively.
-Each victory in the gym awards points equal to 1\% of the defeated Pokémon's CP.
+Each victory in the gym awards points equal to 1\% of the defeated Pokémon's \CP\@.
 Losing or retreating results in a consolation prize of five gym points.
 Installing a defender yields 100; feeding a berry to a defender nets 10,
  and a point is awarded for each minute's occupancy.

--- a/006-pgo/battle.tex
+++ b/006-pgo/battle.tex
@@ -525,7 +525,7 @@ Each Trainer can use up to five purified gems, with a five second delay between 
 Transitions into the enraged and subdued states are noted with messages.
 
 Boss Pokémon share base ATK and DEF with their normal brethren, with a 15/15/0 IV\@.
-Their \MHP is greatly augmented (\autoref{table:raidmhp}).
+Their \MHP{} is greatly augmented (\autoref{table:raidmhp}).
 Shadow bosses sometimes get a further boost to \MHP\@.
 \begin{table}
 \centering
@@ -541,7 +541,7 @@ Shadow bosses sometimes get a further boost to \MHP\@.
   Primal & 22,500 & n/a & 5\\
   6🟉 & 22,500 & n/a & 5\\
 \end{tabular}
-\caption{\MHP for raid bosses\label{table:raidmhp}}
+\caption{\MHP{} for raid bosses\label{table:raidmhp}}
 \end{table}
 A successful raid is followed by a ``Bonus challenge'', an encounter with the Boss Pokémon.
 This Pokémon will have its own IVs, and the same base stats as any other member of its species.

--- a/006-pgo/battle.tex
+++ b/006-pgo/battle.tex
@@ -10,7 +10,7 @@ Aside from Trainer Battles, Trainers can make use of items in the screen before
   battle is entered (called the ``lobby'', especially in an Nx1 context), and
   likewise engage Mega evolutions.
 Pokémon exchange fast attacks (and, when enough energy has been built up, charged attacks)
-  until one side is entirely reduced to zero HP (or surrenders).
+  until one side is entirely reduced to zero \HP{} (or surrenders).
 
 Remember that attacks typically have different power and energy stats depending on
   whether it's a 3x3 or Nx1 context (\autoref{chap:attacks}).
@@ -21,9 +21,9 @@ This integer is called (inflicted) damage $D$, and calculated as a product of se
 \section{The typing multiplier\label{sec:typemult}}
 Determine $M_C$, the common multiplier due typing:
 
-\[ M_C = M_{STAB} \cdot 1.6^{T} \]
+\[ M_\mathrm{C} = M_\mathrm{STAB} \cdot 1.6^{T} \]
 
-$M_{STAB}$ is the STAB bonus, equal to 1.2 when the attack's type matches any
+$M_\mathrm{STAB}$ is the STAB bonus, equal to 1.2 when the attack's type matches any
   type of the attacker, and 1 otherwise.
 $T$ is the number calculated in \autoref{chap:types} using the attack type
  and the defender's type.
@@ -46,7 +46,7 @@ $T$ & $1.6^{T}$ & Δ\% & w/ STAB & Δ\% \\
 \caption{Typing multipliers with and without STAB\label{table:typemult}}
 \end{table}
 
-Leaving out the hideous −4 case, we see that $M_C$ ranges
+Leaving out the hideous −4 case, we see that $M_\mathrm{C}$ ranges
  from 0.2441 (a 75.59\% reduction in damage) to 3.072
  (a 207.2\% increase).
 Considered another way, for an effectiveness of −3 with no STAB bonus,
@@ -55,7 +55,7 @@ Considered another way, for an effectiveness of −3 with no STAB bonus,
 With an effectiveness of 2 with STAB, it takes about one-third as many attacks.
 
 Note that the change due to a $T$ of 1 (60\%) is similar in magnitude to the change
- when $T$ is −2 (−60.94\%). A $T$ of −1 is a smaller loss (−37.5\%).
+ when $T$ is −2 (−60.94\%). A $T$ of −1 is a smaller loss (\hbox{−37.5\%}).
 This does not mean that an attack ineffective against one of the defender's types and
  effective against the other enjoys a 22.5\% gain (as one would see from $1.6^{−1} + 1.6^{1})$!
 The multiplier is 1, and results in no change ($1.6^{−1+1}$).
@@ -65,11 +65,11 @@ Exponential functions are not linear functions, and must not be treated as such.
 
 \section{The context-specific multiplier\label{sec:mbmult}}
 In Raids and Max battles, a number of effects come into play.
-\[ M_B = 0.5 \cdot M_D \cdot M_F \cdot M_W \cdot M_M \]
+\[ M_\mathrm{B} = 0.5 \cdot M_\mathrm{D} \cdot M_\mathrm{F} \cdot M_\mathrm{W} \cdot M_\mathrm{M} \]
 \begin{itemize}
- \item $M_D$ is 0.25 if the attack is dodged (dodging is only possible in Raids/Max battles),
+ \item $M_\mathrm{D}$ is 0.25 if the attack is dodged (dodging is only possible in Raids/Max battles),
  and 1 otherwise. Note that this seems to have been subject to recent changes.
- \item The friendship bonus $M_F$:
+ \item The friendship bonus $M_\mathrm{F}$:
    \begin{table}[h!]
 \centering
        \begin{tabular}{lc}
@@ -83,15 +83,15 @@ In Raids and Max battles, a number of effects come into play.
        \end{tabular}
      \caption{Bonus due the presence of friends}
    \end{table}
- \item $M_W$ is 1.2 if the attack is weather-boosted, and 1 otherwise.
- \item $M_M$ from Mega Pokémon \textit{actively} involved in a Raid (i.e. they
+ \item $M_\mathrm{W}$ is 1.2 if the attack is weather-boosted, and 1 otherwise.
+ \item $M_\mathrm{M}$ from Mega Pokémon \textit{actively} involved in a Raid (i.e. they
    must be fighting, not just on the team), or Primal Pokémon \textit{present}
    (even knocked out) at a Raid or Gym. The Primal bonus is not awarded to the Trainer who brought
    that Primal Pokémon, but they can receive it from some other Trainer's Pokémon.
    \begin{table}[h!]
      \centering
        \begin{tabular}{p{.7\textwidth}c}
-         Situation & $M_M$ \\
+         Situation & $M_\mathrm{M}$ \\
          \Midrule
          No active Mega Pokémon, and no Primal Pokémon brought
           by other Trainers present, \textit{unless…} & 1 \\
@@ -103,12 +103,12 @@ In Raids and Max battles, a number of effects come into play.
        \end{tabular}
      \caption{Bonus due the presence of Mega and Primal Pokémon}
    \end{table}
-   In a Max battle, $M_M$ is based on the number of Pokémon left at that Power Stop
+   In a Max battle, $M_\mathrm{M}$ is based on the number of Pokémon left at that Power Stop
      (see \autoref{sec:maxbattles}).
    \begin{table}[h!]
      \centering
        \begin{tabular}{lc}
-         Pokémon present at Power Stop & $M_M$ \\
+         Pokémon present at Power Stop & $M_\mathrm{M}$ \\
          \Midrule
          0 & 1 \\
          1 & 1.1 \\
@@ -143,11 +143,11 @@ Level & Multiplier & Comment \\
 \end{tabular}
 \caption{Mapping buff/nerf stages to effect\label{table:buffs}}
 \end{table}
-For fast attacks, $M_G$ is 1.
+For fast attacks, $M_\mathrm{G}$ is 1.
 When throwing a charged attack, the attacking Trainer plays a short minigame.
 Performance on this minigame is summarized with ``Excellent!'', ``Great!'',
 ``Nice!'', or silence.
-This summary is a low-resolution signal of $M_G$, with a range over [0.25, 1].
+This summary is a low-resolution signal of $M_\mathrm{G}$, with a range over [0.25, 1].
 ``Excellent!'' is necessary and sufficient for a 1, and should always be obtainable.
 \begin{table}
 \centering
@@ -159,48 +159,48 @@ Summary & $M_G$ range (no Shield) \\
 ``Nice!'' & [0.5, 0.75) \\
 No summary & [0.25, 0.5) \\
 \end{tabular}
-\caption{The minigame summary is an indication of $M_G$}
+\caption{The minigame summary is an indication of $M_\mathrm{G}$}
 \end{table}
 Each Trainer gets two shields in a battle, each of which can be used
  to block a single charged attack.
-If a shield is used, $M_G$ is 0, no matter the minigame performance.
+If a shield is used, $M_\mathrm{G}$ is 0, no matter the minigame performance.
 The effect is equivalent to raising the defender's DEF to infinity for the
   duration of the attack.
 
 \section{The damage equation\label{sec:damage}}
 
-$D_A$ is what we can calculate using only the attacker's knowledge, i.e.
+$D_\mathrm{A}$ is what we can calculate using only the attacker's knowledge, i.e.
  it is that component of $D$ which is independent of the defender.
 
-\[ D_A = P \cdot \mathit{Eff_A} \cdot M_{STAB} \cdot M_B \]
+\[ D_\mathrm{A} = P \cdot \Eff{A} \cdot M_\mathrm{STAB} \cdot M_\mathrm{B} \]
 
 Since this is a product, a proportional increase in any factor leads to
  the same change.
-Suppose a Level 12 Pokémon (CPM: 0.4628) with $Mod_A$ of 140 runs
+Suppose a Level 12 Pokémon (\CPM: 0.4628) with \Mod{A} of 140 runs
   a fast attack with a power of 10 and no STAB bonus.
-The resulting $D_A$ is 421.148.
+The resulting $D_\mathrm{A}$ is 421.148.
 Increasing power to 12,
- increasing $Mod_A$ to 168,
+ increasing \Mod{A} to 168,
  acquiring the STAB bonus,
- or increasing CPM 20\% to 0.55536 (somewhere between Levels 17 and 17.5; this exact change is not possible)
- all yield a 20\% increase in $D_A$, 505.3776.
+ or increasing \CPM{} 20\% to 0.55536 (somewhere between Levels 17 and 17.5; this exact change is not possible)
+ all yield a 20\% increase in $D_\mathrm{A}$, 505.3776.
 Note that this is all independent of the opponent.
 
-$D_A$ is divided by $\mathit{Eff_D}$ and scaled by $1.6^T$:
+$D_\mathrm{A}$ is divided by \Eff{D} and scaled by $1.6^T$:
 
-\[ D_D = \frac{D_A}{\mathit{Eff_D}} \cdot 1.6^T \]
+\[ D_\mathrm{D} = \frac{D_\mathrm{A}}{\Eff{D}} \cdot 1.6^T \]
 
 We can recover our defined multipliers:
 
-\[ D_D = P \cdot \frac{\mathit{Eff_A}}{\mathit{Eff_D}} \cdot M_C \cdot M_B \]
+\[ D_\mathrm{D} = P \cdot \frac{\Eff{A}}{\Eff{D}} \cdot M_\mathrm{C} \cdot M_\mathrm{B} \]
 
-Using the definitions of $\mathit{Eff_A}$ and $\mathit{Eff_D}$, this can be rewritten as:
+Using the definitions of \Eff{A} and \Eff{D}, this can be rewritten as:
 
-\[ D_D = P \cdot \frac{Mod_A \cdot CPM_A}{Mod_D \cdot CPM_D} \cdot M_C \cdot M_B \]
+\[ D_\mathrm{D} = P \cdot \frac{\Mod{A} \cdot \CPM_\mathrm{A}}{\Mod{D} \cdot \CPM_\mathrm{D}} \cdot M_\mathrm{C} \cdot M_\mathrm{B} \]
 
 which can of course be rewritten as:
 
-\[ D_D = P \cdot \frac{Mod_A}{Mod_D} \cdot \frac{CPM_A}{CPM_D} \cdot M_C \cdot M_B \]
+\[ D_\mathrm{D} = P \cdot \frac{\Mod{A}}{\Mod{D}} \cdot \frac{\CPM_\mathrm{A}}{\CPM_\mathrm{D}} \cdot M_\mathrm{C} \cdot M_\mathrm{B} \]
 
 This is always a positive rational.
 A floor function is applied (ensuring a non-negative integer),
@@ -208,54 +208,54 @@ A floor function is applied (ensuring a non-negative integer),
 
 \[ D = \left\lfloor P \cdot \frac{\mathit{Eff_A}}{\mathit{Eff_D}} \cdot M_C \cdot M_B \right\rfloor + 1 \]
 
-If $D$ equals or exceeds the opponent's HP, it will fight no more.
+If $D$ equals or exceeds the opponent's \HP, it will fight no more.
 
 \section{Opponent-independent damage}
 We can break the damage equation into those parts dependent upon opponents, and those which are independent.
-Looking at the damage equation, power, $\mathit{Eff_A}$, and STAB do not depend upon an attacker's opponent.
-Likewise $\mathit{Eff_D}$ and MHP for the defender.
-The attacker knows neither $\mathit{Eff_D}$ nor MHP, while the defender doesn't know $\mathit{Eff_A}$.
+Looking at the damage equation, power, \Eff{A}, and STAB do not depend upon an attacker's opponent.
+Likewise \Eff{D} and \MHP{} for the defender.
+The attacker knows neither \Eff{D} nor \MHP, while the defender doesn't know \Eff{A}.
 Knowing type effectiveness always requires knowing the opposing typing.
 We can thus define an independent core fitness evaluation:
 
-\[ F = \mathit{Eff_A} \cdot P \cdot M_{STAB} \cdot \mathit{Eff_D} \cdot MHP \]
+\[ F = \Eff{A} \cdot P \cdot M_\mathrm{STAB} \cdot \Eff{D} \cdot \MHP \]
 
-Note that CPM is implicitly cubed in this function.
+Note that \CPM{} is implicitly cubed in this function.
 
 Of course, a given Pokémon can generally select from multiple fast and charged attacks,
   knowing up to two of the latter at a given time.
 Furthermore, fast and charged attacks are not used in equal ratio (there will
   always be multiple fast attacks per charged attack), and a shield can
   nullify a charged attack.
-How do we define $P$ and $M_{STAB}$?
+How do we define $P$ and $M_\mathrm{STAB}$?
 As only one fast attack can be known at a time, it's easy enough to define one
   fitness for each possible fast attack, leaving out charged attacks for now.
 All we need do is normalize the power of the fast attack, using the number of
   Turns it requires.
 
-\[ F = \mathit{Eff_A} \cdot \frac{P_{Fast}}{T_{Fast}} \cdot M_{STAB-Fast} \cdot \mathit{Eff_D} \cdot \mathit{Eff_S} \]
+  \[ F = \Eff{A} \cdot \frac{P_\mathrm{Fast}}{T_\mathrm{Fast}} \cdot M_\mathrm{STAB-Fast} \cdot \Eff{D} \cdot \Eff{S} \]
 
 Integrating charged attacks is more complex.
 First, we can simply normalize the charged attack as we did the fast attack,
  determine the number of fast attacks necessary to launch it:
 
-\[ N_{Fast} = \left\lceil\frac{E_{Charged}}{E_{Fast}}\right\rceil \]
+\[ N_\mathrm{Fast} = \left\lceil\frac{E_\mathrm{Charged}}{E_\mathrm{Fast}}\right\rceil \]
 
 yielding the total power of a cycle.
 
-\[ TDO = N_{Fast} \cdot P_{Fast} + P_{Charged} \]
+\[ \mathit{TDO} = N_\mathrm{Fast} \cdot P_\mathrm{Fast} + P_\mathrm{Charged} \]
 
 We normalize this by the turns of a full cycle:
 
-\[ F_{cycle} = \frac{TDO}{N_{Fast} \cdot T_{Fast} + T_{Charged}} \]
+\[ F_\mathrm{cycle} = \frac{\mathit{TDO}}{N_\mathrm{Fast} \cdot T_\mathrm{Fast} + T_\mathrm{Charged}} \]
 
 There are two turns per second.
-Multiplying $F_{cycle}$ by two yields a stat the community calls Damage Per Second (DPS).
+Multiplying $F_\mathrm{cycle}$ by two yields a stat the community calls Damage Per Second (DPS).
 
 This has several problems, almost all related to charged attacks.
 It doesn't account for the possibility of knowing two charged attacks.
 It doesn't account for leftover energy, which will sometimes be present if
-  $E_{Charged}$ is not a multiple of $E_{Fast}$ (i.e. $N_{Fast}$
+  $E_\mathrm{Charged}$ is not a multiple of $E_\mathrm{Fast}$ (i.e. $N_\mathrm{Fast}$
   might fluctuate from one cycle to the next).
 It ignores the possibility that the attacker might not use its charged attack
   immediately (and it is often unwise to throw charged attacks as quickly as
@@ -272,41 +272,41 @@ We can hardly ignore charged attacks: they tend to dominate our total inflicted 
 \end{figure}
 
 If we expand over multiple cycles of fast and charged attacks, we can
- generalize to situations with excess energy. We know $E_{Charged} \cdot
- E_{Fast}$ will be a multiple of both the generated and consumed energy, so
- simply consider $E_{Charged}$ cycles, each of which throws an average of
- $\frac{E_{Charged}}{E_{Fast}}$ fast attacks followed by one charged attack.
+ generalize to situations with excess energy. We know $E_\mathrm{Charged} \cdot
+ E_\mathrm{Fast}$ will be a multiple of both the generated and consumed energy, so
+ simply consider $E_\mathrm{Charged}$ cycles, each of which throws an average of
+ $\frac{E_\mathrm{Charged}}{E_\mathrm{Fast}}$ fast attacks followed by one charged attack.
 
-\[ P_{cycles} = E_{Charged} \cdot \left(\frac{E_{Charged}}{E_{Fast}} \cdot P_{Fast} + P_{Charged}\right) \]
+\[ P_\mathrm{cycles} = E_\mathrm{Charged} \cdot \left(\frac{E_\mathrm{Charged}}{E_\mathrm{Fast}} \cdot P_\mathrm{Fast} + P_\mathrm{Charged}\right) \]
 
- The number of fast attacks in a cycle is actually always either
- $\lfloor\frac{E_{Charged}}{E_{Fast}}\rfloor$
- or $\lceil\frac{E_{Charged}}{E_{Fast}}\rceil$ (iff $E_{Charged}$ is a multiple of
- $E_{Fast}$, these two expressions are equal, and the number of fast attacks
+The number of fast attacks in a cycle is actually always either
+ $\lfloor\frac{E_\mathrm{Charged}}{E_\mathrm{Fast}}\rfloor$
+ or $\lceil\frac{E_\mathrm{Charged}}{E_\mathrm{Fast}}\rceil$ (iff $E_\mathrm{Charged}$ is a multiple of
+ $E_\mathrm{Fast}$, these two expressions are equal, and the number of fast attacks
  per charged attack is constant). Normalize for the total time:
 
-\[ F_{cycles} = \frac{P_{cycles}}{E_{Charged} \cdot \left(\frac{E_{Charged}}{E_{Fast}} \cdot T_{Fast} + T_{Charged}\right)} \]
+\[ F_\mathrm{cycles} = \frac{P_\mathrm{cycles}}{E_\mathrm{Charged} \cdot \left(\frac{E_\mathrm{Charged}}{E_\mathrm{Fast}} \cdot T_\mathrm{Fast} + T_\mathrm{Charged}\right)} \]
 
 This has only exacerbated one of the problems we mentioned before: we may
   not get to throw all these attacks!
-Suppose we have some constant chance $0 < L_{KO} \leq 1$ of being knocked out or
+Suppose we have some constant chance $0 < L_\mathrm{KO} \leq 1$ of being knocked out or
  substituted following each attack we launch, the probability of being
- in to throw the $N$th attack is $(1 - L_{KO})^{N-1}$.
+ in to throw the $N$th attack is $(1 - L_\mathrm{KO})^{N-1}$.
 We could thus define an expected damage from attack $N$:
 
-\[ E_D(N) = \overline{P} \cdot (1 - L_{KO})^{N-1} \]
+\[ E_\mathrm{D}(N) = \overline{P} \cdot (1 - L_\mathrm{KO})^{N-1} \]
 
 and a cumulative expected damage through $N$ attacks:
 
-\[ E_{TD}(N) = \sum^N_{i=1} \overline{P} \cdot (1 - L_{KO})^{i-1} \]
+\[ E_\mathrm{TD}(N) = \sum^N_{i=1} \overline{P} \cdot (1 - L_\mathrm{KO})^{i-1} \]
 
-This is a geometric series where $a = \overline{P}$ and $r = 1 - L_{KO}$.
+This is a geometric series where $a = \overline{P}$ and $r = 1 - L_\mathrm{KO}$.
 Since $0 \leq r < 1$, this series converges to
 
-\[ E_{TD}(\infty) = \sum^\infty_{i=1} \overline{P} \cdot r^{i-1} = \frac{\overline{P}}{1 - L_{KO}} \]
+\[ E_\mathrm{TD}(\infty) = \sum^\infty_{i=1} \overline{P} \cdot r^{i-1} = \frac{\overline{P}}{1 - L_\mathrm{KO}} \]
 
 Of course, our chance of being knocked out is usually not constant across
- attacks, but rather an immediate function of our remaining HP and any
+ attacks, but rather an immediate function of our remaining \HP{} and any
  damage we are about to absorb.
 
 \section{3x3 battles\label{sec:3x3}}
@@ -336,7 +336,7 @@ Charged attacks cannot be simultaneous; if both Trainers launch a charged attack
   on the same turn, one goes first,and can knock out the opponent before it
   launches its attack.
 The Pokémon that goes first (``Charged Move Priority'') is the one with the
-  higher $\mathit{Eff_{ARaw}}$ (recall that this is base attack plus $IV_A$, times CPM, but does not reflect the Shadow bonus).
+  higher $\mathit{Eff_{ARaw}}$ (recall that this is base attack plus $\mathit{IV_A}$, times CPM, but does not reflect the Shadow bonus).
 Shadow status does not factor into consideration, nor do any active buffs.
 3x3 battles take place four ways: with other Trainers via the friends list,
  with Team Leaders via the Battle screen, the GO Battle League,
@@ -471,7 +471,7 @@ While in the Gym, the Pokémon still counts against the Trainer's storage,
   but it cannot be interacted with in any way save feeding it Berries.
 Berries can be fed to any Pokémon defending a coaligned Gym, though
   each defender can consume only ten berries per thirty minutes.
-Pokémon defending the gym steadily lose HP (``motivation'') at a rate
+Pokémon defending the gym steadily lose \HP{} (``motivation'') at a rate
   based on their CP (\autoref{sec:cp}).
 The first and second loss both cut 28\% of max motivation, while
   a third loss always knocks the defender out of the gym;
@@ -502,7 +502,7 @@ If all six are defeated, their Trainer can optionally continue with another team
 Only one Pokémon of each Trainer is active at a time, but there is unlimited substitution within the team.
 These raids have their own time limits, and the raid ends when the boss is defeated, no more Pokémon remain fighting,
   or the timer (180 seconds for raids below the 5🟉 difficulty level, and 300 seconds otherwise) expires.
-The contest is primarily against this timer, so prioritize Shadow Pokémon and high $\mathit{Eff_A}$.
+The contest is primarily against this timer, so prioritize Shadow Pokémon and high \Eff{A}.
 
 A raid gym has zero or more associated lobbies, each capable of holding twenty Trainers.
 Empty lobbies are immediately destroyed.
@@ -516,21 +516,21 @@ Showing a pass is required to enter the lobby, but the pass is only consumed whe
 Involved Trainers can reattempt a failed raid without a second pass.
 
 Shadow raids are backed by Team GO Rocket, and feature Shadowed bosses.
-Shadow bosses ranked 3🟉 or more will enter a dangerous ``enraged'' state after losing about ⅓ of their HP.
-While enraged, the Pokémon enjoys higher attack and defense, regenerates HP, and is surrounded by a purple aura.
-Eight purified gems will subdue an enraged boss, as will falling to about 15\% of original HP.
+Shadow bosses ranked 3🟉 or more will enter a dangerous ``enraged'' state after losing about ⅓ of their \HP.
+While enraged, the Pokémon enjoys higher attack and defense, regenerates \HP, and is surrounded by a purple aura.
+Eight purified gems will subdue an enraged boss, as will falling to about 15\% of original \HP.
 Each Trainer can use up to five purified gems, with a five second delay between uses
  (note that this is insufficient to subdue the boss, making 3🟉+ shadow raids
  very difficult for solo Trainers).
 Transitions into the enraged and subdued states are noted with messages.
 
 Boss Pokémon share base ATK and DEF with their normal brethren, with a 15/15/0 IV\@.
-Their MHP is greatly augmented (\autoref{table:raidmhp}).
-Shadow bosses sometimes get a further boost to MHP\@.
+Their \MHP is greatly augmented (\autoref{table:raidmhp}).
+Shadow bosses sometimes get a further boost to \MHP\@.
 \begin{table}
 \centering
 \begin{tabular}{llll}
-  Tier & MHP & Shadow MHP & Time (min)\\
+  Tier & \MHP & Shadow \MHP & Time (min)\\
   \Midrule
   1🟉 & 600 & 600 & 3 \\
   2🟉 & 1,800 & n/a & 3\\
@@ -541,7 +541,7 @@ Shadow bosses sometimes get a further boost to MHP\@.
   Primal & 22,500 & n/a & 5\\
   6🟉 & 22,500 & n/a & 5\\
 \end{tabular}
-\caption{MHP for raid bosses\label{table:raidmhp}}
+\caption{\MHP for raid bosses\label{table:raidmhp}}
 \end{table}
 A successful raid is followed by a ``Bonus challenge'', an encounter with the Boss Pokémon.
 This Pokémon will have its own IVs, and the same base stats as any other member of its species.
@@ -596,7 +596,7 @@ Trainers whose Pokémon have all fainted can cheer along their teammates,
 The majority of damage is likely to be dealt while in Max form.
 Filling the Max Meter is essential, as is keeping elite Max forms alive.
 A basic strategy for Max battles is thus to do most attacking with a Pokémon having
-  high defense and MHP, employing moves of low duration.
+  high defense and \MHP, employing moves of low duration.
 Single-turn fast attacks are ideal.
 Each will advance the Max Meter, and flurries of fast attacks are likely to
  fill it faster than lengthy charged attacks.
@@ -659,13 +659,13 @@ When the Power Stop expires, installed Pokémon immediately return to their Trai
 Damage to your Pokémon persists after a Raid, Max Battle, or 3x3 with Team GO Rocket ends.
 Those which fainted will remain fainted until a Revive or Max Revive is applied.
 While fainted, they cannot be brought into battle.
-Powering up a fainted Pokémon will revive them with minimal HP (\autoref{sec:plevel}),
-  while evolving one restores full HP (\autoref{sec:evolution}).
-A regular Revive brings the Pokémon back with half of MHP; the Max Revive restores full HP.
+Powering up a fainted Pokémon will revive them with minimal \HP{} (\autoref{sec:plevel}),
+  while evolving one restores full \HP{} (\autoref{sec:evolution}).
+A regular Revive brings the Pokémon back with half of \MHP; the Max Revive restores full \HP.
 If the Pokémon isn't fainted, but merely damaged, four levels of Potion
-  restore various amounts of HP, never exceeding MHP\@.
-Hyper Potions heal up 200 HP, sufficient to restore all but the bulkiest Pokémon to MHP.
-For them, there exist Max Potions, which go all the way to MHP.
+  restore various amounts of \HP, never exceeding \MHP\@.
+Hyper Potions heal up 200 \HP, sufficient to restore all but the bulkiest Pokémon to \MHP.
+For them, there exist Max Potions, which go all the way to \MHP.
 Potions cannot be applied to fainted Pokémon; they must first be revived.
 Potions and Revives are level-gated, but once unlocked can be semi-randomly acquired
   from Gifts (\autoref{sec:gifts}),
@@ -680,12 +680,12 @@ Potions and Revives are level-gated, but once unlocked can be semi-randomly acqu
 \begin{tabular}{ll}
 Item & Effect \\
 \Midrule
-Potion & Restore 20 HP, not to exceed MHP\\
-Super Potion & Restore 50 HP, not to exceed MHP\\
-Hyper Potion & Restore 200 HP, not to exceed MHP\\
-Max Potion & Restore to full MHP\\
-Revive & Revive with half of MHP\\
-Max Revive & Revive with full MHP\\
+Potion & Restore 20 \HP, not to exceed \MHP\\
+Super Potion & Restore 50 \HP, not to exceed \MHP\\
+Hyper Potion & Restore 200 \HP, not to exceed \MHP\\
+Max Potion & Restore to full \MHP\\
+Revive & Revive with half of \MHP\\
+Max Revive & Revive with full \MHP\\
 \end{tabular}
 \caption{Potions and revives\label{table:potions}}
 \end{table}

--- a/006-pgo/bounded.cpp
+++ b/006-pgo/bounded.cpp
@@ -105,7 +105,7 @@ void print_bounded_table(int bound, float lbound, bool amean){
   printf("\\footnotesize\n");
   printf("\\setlength{\\tabcolsep}{1pt}\n");
   printf("\\begin{longtable}{lrrrrrrrr}\n");
-  printf("Species & IV·L & HP & $\\mathit{Eff_A}$ & $\\mathit{Eff_D}$ & $\\frac{BS}{3}$ & $\\sqrt[3]{BP}$ & CP & A\\%% \\\\\n");
+  printf("Species & IV·L & \\HP & \\Eff{A} & \\Eff{D} & $\\frac{BS}{3}$ & $\\sqrt[3]{\\BP\\,}$ & \\CP & $A\\%%$ \\\\\n");
   printf("\\Midrule\n");
   printf("\\endhead\n");
   stats *sols = NULL;
@@ -122,7 +122,7 @@ void print_bounded_table(int bound, float lbound, bool amean){
   while( (sols = print_sol_set(sols)) ){
     ;
   }
-  printf("\\captionlistentry{Optimal solutions bounded by %d CP}\n", bound);
+  printf("\\captionlistentry{Optimal solutions bounded by %d \\CP}\n", bound);
   printf("\\label{table:cp%d%c}\n", bound, amean ? 'a' : 'g');
   printf("\\end{longtable}\n");
   printf("\\endgroup\n");

--- a/006-pgo/bounded.cpp
+++ b/006-pgo/bounded.cpp
@@ -105,7 +105,7 @@ void print_bounded_table(int bound, float lbound, bool amean){
   printf("\\footnotesize\n");
   printf("\\setlength{\\tabcolsep}{1pt}\n");
   printf("\\begin{longtable}{lrrrrrrrr}\n");
-  printf("Species & IV·L & HP & $Eff_A$ & $Eff_D$ & $\\frac{BS}{3}$ & $\\sqrt[3]{BP}$ & CP & A\\%% \\\\\n");
+  printf("Species & IV·L & HP & $\\mathit{Eff_A}$ & $\\mathit{Eff_D}$ & $\\frac{BS}{3}$ & $\\sqrt[3]{BP}$ & CP & A\\%% \\\\\n");
   printf("\\Midrule\n");
   printf("\\endhead\n");
   stats *sols = NULL;

--- a/006-pgo/bounded.tex
+++ b/006-pgo/bounded.tex
@@ -15,7 +15,8 @@ We then select a team using the strategies of that chapter. Since
  that list was sorted according to a general strength function, it
  ought apply in this reduced context.
 
-\section{Optimal IVs and Levels under a \CP{} bound}
+\section[Optimal IVs and Levels under a \CP{} bound]%
+{Optimal IVs and Levels under a $\mathbfit{C\kern -1ptP}$\, bound}
 We require a fitness function that takes as input a Pokémon's form, level, and IV,
   and emits a comparable output.
   Common functions include \CP{} itself, the arithmetic mean ($\frac{\mathit{Eff_\mathrm{A}} +\mathit{Eff_\mathrm{D}} + \mathit{MHP}}{3}$),
@@ -94,8 +95,8 @@ There are many fitness functions. In the Gurdurr example given previously, 3--2-
     \[ \left\lfloor \frac{129.36 \cdot 4 \cdot 1.2}{101.49} \right\rfloor = \lfloor 6.118 \rfloor = 6 \]
  The supposedly optimal Gurdurr strikes for six as well:
     \[ \left\lfloor \frac{123.29 \cdot 4 \cdot 1.2}{96.136} \right\rfloor = \lfloor 6.156 \rfloor = 6 \]
- At 145 HP, Gurdurr goes down on the 25th attack.
- Its opponent's 139 HP absorbs 23 attacks before falling to the 24th, but this could
+ At 145 \HP, Gurdurr goes down on the 25th attack.
+ Its opponent's 139 \HP{} absorbs 23 attacks before falling to the 24th, but this could
     have easily gone the other way.
  If the attack's Power were 10, both hit for nine damage, and both fall after nine attacks.
 

--- a/006-pgo/bounded.tex
+++ b/006-pgo/bounded.tex
@@ -19,7 +19,7 @@ We then select a team using the strategies of that chapter. Since
 We require a fitness function that takes as input a Pokémon's form, level, and IV,
   and emits a comparable output.
 Common functions include CP itself, the arithmetic mean ($\frac{Eff_A +Eff_D + MHP}{3}$),
-  and the geometric mean ($\sqrt[3]{Eff_A \cdot Eff_D \cdot MHP}$)\footnote{I personally believe the geometric mean to best match Pokémon GO's
+  and the geometric mean ($\sqrt[3]{\mathit{Eff_A} \cdot \mathit{Eff_D} \cdot MHP}$)\footnote{I personally believe the geometric mean to best match Pokémon GO's
   mechanics, but there is no true ``best'' fitness function---optimal IVs are
   dependent upon both the base stats and the opponent.}.
 Optimizing for maximum minimum stat is also intriguing.
@@ -30,10 +30,10 @@ Higher IV components might require a lower level than lower components to
 What can be said is that IVs add less value to a high base stat than a low
  base stat, and that higher levels provide diminishing returns.
 For a base stat of 100, a corresponding IV component of 15 represents a
- 15\% improvement to $Eff_A$.
+ 15\% improvement to $\mathit{Eff_A}$.
 For a base stat of 300, the same IV represents only a 5\% improvement.
 A Level 10 Pokémon advancing to level 10.5 enjoys a 2.47\% improvement to
- $Eff_A$ (and also $Eff_D$ and $Eff_S$), paying a price of 5\% increase
+ $\mathit{Eff_A}$ (and also $\mathit{Eff_D}$ and $\mathit{Eff_S}$), paying a price of 5\% increase
  in CP.
 Advancing from 30 to 30.5 represents only a 0.42\% improvement (and a
  0.83\% increase in CP).
@@ -46,7 +46,7 @@ The maximum level for which a 0--0--0 IV comes in under the bound is the
  while remaining within the bound.
 Any IV with all three components less than or equal to another IV, but bounded
  by the same level, is strictly inferior to the second IV, and can be discarded.
-Compute $Eff_A$, $Eff_D$, and $MHP$ using the IVs and corresponding levels.
+Compute $\mathit{Eff_A}$, $\mathit{Eff_D}$, and $MHP$ using the IVs and corresponding levels.
 Any resulting set with all three components less than or equal to some other set's
  is strictly inferior to the second, and can be discarded.
 This captures $MHP$'s floor function.
@@ -57,7 +57,7 @@ What remains is an optimal frontier of at least one solution (usually
 
 Before taking Power and Type into the question, let's examine the optimal
  solutions for a genus using the 1500 and 2500 CP bounds, using the
- geometric mean of $Eff_A$, $Eff_D$, and $MHP$ as our global fit function.
+ geometric mean of $\mathit{Eff_A}$, $\mathit{Eff_D}$, and $MHP$ as our global fit function.
 Timburr (134 ATK, 87 DEF, and 181 STA) evolves into
   Gurdurr (180 ATK, 134 DEF, and 198 STA), which evolves into
   Conkeldurr (243 ATK, 158 DEF, 233 STA).
@@ -87,8 +87,8 @@ Take two things away from this:
     mean 120.015), but 1/15/15@26 beats it at 1496 (121.968).
 \end{itemize}
 There are many fitness functions. In the Gurdurr example given previously, 3--2--0 loses
-    to 1--15--15 at geometric mean, but has an $Eff_A$ of 129.36, comfortably above the latter's 123.29.
- Does this compensate for six fewer hit points (145 vs 139) and lower $Eff_D$ (101.49 vs 96.136)?
+    to 1--15--15 at geometric mean, but has an $\mathit{Eff_A}$ of 129.36, comfortably above the latter's 123.29.
+ Does this compensate for six fewer hit points (145 vs 139) and lower $\mathit{Eff_D}$ (101.49 vs 96.136)?
  Let's pit them against one another, using Low Kick (Power of 4, neutral type effectiveness, STAB bonus).
  Our Level 28 competitor strikes for six damage with each attack:
     \[ \left\lfloor \frac{129.36 \cdot 4 \cdot 1.2}{101.49} \right\rfloor = \lfloor 6.118 \rfloor = 6 \]
@@ -103,7 +103,7 @@ There are many fitness functions. In the Gurdurr example given previously, 3--2-
 Pokémon GO offers two CP-bounded PvP leagues, the Great League (CP 1500) and
    the Ultra League (CP 2500).
 \autoref{table:cp1500g} lists species' optimal level and IVs for the Great League
-  as evaluated using the geometric mean of $Eff_A$, $Eff_D$, and $MHP$.
+  as evaluated using the geometric mean of $\mathit{Eff_A}$, $\mathit{Eff_D}$, and $MHP$.
 Species which can't manage a geometric mean of 124.66 have been left out.
 \autoref{table:cp2500g} does the same for the Ultra League, eliding those species which
   can't hit a $\sqrt[3]{BP}$ of 156.78.
@@ -118,12 +118,12 @@ There is a strong bimodal preference for IVs: 15/15/15 for level 49.5
 This verifies (not that we had any doubt) that attack is highly overvalued in the CP calculation relative to $\sqrt[3]{BP}$.
 Other IVs usually correspond to low level, powerful species, where a level
   raises CP by a large amount, leaving more room for beneficial IVs.
-$Eff_A$ ranges from 63.02 (Chansey) to tremendous outlier 254.05 (Deoxys Attack).
-In general, the top positions have relatively low $Eff_A$, rising in an
+$\mathit{Eff_A}$ ranges from 63.02 (Chansey) to tremendous outlier 254.05 (Deoxys Attack).
+In general, the top positions have relatively low $\mathit{Eff_A}$, rising in an
   orderly fashion to about 145 as we go down the list.
 At this point, they become more disordered, until falling at the back
   of the list.
-$MHP$ and $Eff_D$ are much less predictable.
+$MHP$ and $\mathit{Eff_D}$ are much less predictable.
 \begin{figure}
 \begin{minipage}{0.5\textwidth}\begin{center}
 \includegraphics[width=\textwidth,keepaspectratio]{octave/greninjalevels.png}
@@ -165,8 +165,8 @@ One has to be careful choosing, though; most end up woefully underpowered
 \section{Breakpoints\label{sec:breakpoints}}
 Should you have (or believe you have) a good idea of what you'll be going up against,
  breakpoint analysis is a powerful tool.
-Essentially, we want to model the relationship between two Pokémons' $Eff_D$
- and $Eff_A$.
+Essentially, we want to model the relationship between two Pokémons' $\mathit{Eff_D}$
+ and $\mathit{Eff_A}$.
 Alternately, we want to model damage inflicted against MHP\@.
 Using this information, we can perhaps choose more optimal IVs and levels for a given CP bound.
 This is only as useful as the accuracy of our information, and how narrow a set of opponents it specifies.

--- a/006-pgo/bounded.tex
+++ b/006-pgo/bounded.tex
@@ -1,13 +1,13 @@
 \chapter{Restricted team selection\label{chap:bounded}}
 \textit{This chapter has no relevance for Nx1 battles, nor the Master
-  League, none of which employ CP bounds.}
+  League, none of which employ \CP{} bounds.}
 \bigskip
 
-Several Leagues (and some Research tasks) place a ceiling on the CP of
+Several Leagues (and some Research tasks) place a ceiling on the \CP{} of
  participating Pokémon.
-We have established that CP is a poor proxy for PvP performance, and thus
- expect that we might find strong candidates based on where CP fails.
-If CP does not accurately represent a given Pokémon's chance to win, we ought
+We have established that \CP{} is a poor proxy for PvP performance, and thus
+ expect that we might find strong candidates based on where \CP{} fails.
+If \CP{} does not accurately represent a given Pokémon's chance to win, we ought
  be able to exploit this by assembling teams using undervalued Pokémon\footnote{Michael Lewis might call it ``Moneymon''.}.
 We first take the sorted list of Pokémon developed in \autoref{chap:unbounded},
  and remove all entries not in the optimal sets generated below.
@@ -15,28 +15,28 @@ We then select a team using the strategies of that chapter. Since
  that list was sorted according to a general strength function, it
  ought apply in this reduced context.
 
-\section{Optimal IVs and Levels under a CP bound}
+\section{Optimal IVs and Levels under a \CP{} bound}
 We require a fitness function that takes as input a Pokémon's form, level, and IV,
   and emits a comparable output.
-Common functions include CP itself, the arithmetic mean ($\frac{\mathit{Eff_A} +\mathit{Eff_D} + MHP}{3}$),
-  and the geometric mean ($\sqrt[3]{\mathit{Eff_A} \cdot \mathit{Eff_D} \cdot MHP}$)\footnote{I personally believe the geometric mean to best match Pokémon GO's
+  Common functions include \CP{} itself, the arithmetic mean ($\frac{\mathit{Eff_\mathrm{A}} +\mathit{Eff_\mathrm{D}} + \mathit{MHP}}{3}$),
+  and the geometric mean ($\sqrt[3]{\Eff{A} \cdot \Eff{D} \cdot \MHP}$)\footnote{I personally believe the geometric mean to best match Pokémon GO's
   mechanics, but there is no true ``best'' fitness function---optimal IVs are
   dependent upon both the base stats and the opponent.}.
 Optimizing for maximum minimum stat is also intriguing.
-For a given CP bound, fitness function, and form, there is some optimal set of Pokémon levels
+For a given \CP{} bound, fitness function, and form, there is some optimal set of Pokémon levels
  and individual vectors.
 Higher IV components might require a lower level than lower components to
  come in under the same ceiling.
 What can be said is that IVs add less value to a high base stat than a low
  base stat, and that higher levels provide diminishing returns.
 For a base stat of 100, a corresponding IV component of 15 represents a
- 15\% improvement to $\mathit{Eff_A}$.
+ 15\% improvement to \Eff{A}.
 For a base stat of 300, the same IV represents only a 5\% improvement.
 A Level 10 Pokémon advancing to level 10.5 enjoys a 2.47\% improvement to
- $\mathit{Eff_A}$ (and also $\mathit{Eff_D}$ and $\mathit{Eff_S}$), paying a price of 5\% increase
- in CP.
+ \Eff{A} (and also \Eff{D} and \Eff{S}), paying a price of 5\% increase
+ in \CP{}.
 Advancing from 30 to 30.5 represents only a 0.42\% improvement (and a
- 0.83\% increase in CP).
+ 0.83\% increase in \CP{}).
 
 The maximum level for which a 15--15--15 IV comes in under the bound is the
  minimum possible optimal level, since any lesser level would be strictly less
@@ -46,18 +46,18 @@ The maximum level for which a 0--0--0 IV comes in under the bound is the
  while remaining within the bound.
 Any IV with all three components less than or equal to another IV, but bounded
  by the same level, is strictly inferior to the second IV, and can be discarded.
-Compute $\mathit{Eff_A}$, $\mathit{Eff_D}$, and $MHP$ using the IVs and corresponding levels.
+Compute \Eff{A}, \Eff{D}, and \MHP{} using the IVs and corresponding levels.
 Any resulting set with all three components less than or equal to some other set's
  is strictly inferior to the second, and can be discarded.
-This captures $MHP$'s floor function.
+This captures \MHP{}'s floor function.
 What remains is an optimal frontier of at least one solution (usually
  many solutions), where arguments can be made for each depending on how one
  values attack, defense, and stamina, especially in the context of different
  opponents.
 
 Before taking Power and Type into the question, let's examine the optimal
- solutions for a genus using the 1500 and 2500 CP bounds, using the
- geometric mean of $\mathit{Eff_A}$, $\mathit{Eff_D}$, and $MHP$ as our global fit function.
+ solutions for a genus using the 1500 and 2500 \CP{} bounds, using the
+ geometric mean of \Eff{A}, \Eff{D}, and \MHP{} as our global fit function.
 Timburr (134 ATK, 87 DEF, and 181 STA) evolves into
   Gurdurr (180 ATK, 134 DEF, and 198 STA), which evolves into
   Conkeldurr (243 ATK, 158 DEF, 233 STA).
@@ -65,30 +65,30 @@ Their base products are 2,110,098 (Timburr), 4,775,760 (Gurdurr),
   and 8,945,802 (Conkeldurr).
 The geometric means are 128.263, 168.402, and 207.590.
 Poor Timburr isn't really suited for the common PvP Leagues,
-  and does best with a 15--15--15 at Level 50 (CP 1487).
-Gurdurr can hold its own under a 1500 CP ceiling, and its
-  optimal IVs are 1--15--15 at Level 26 (CP 1496).
+  and does best with a 15--15--15 at Level 50 (\CP{} 1487).
+Gurdurr can hold its own under a 1500 \CP{} ceiling, and its
+  optimal IVs are 1--15--15 at Level 26 (\CP{} 1496).
 It falls short of the Ultra League's 2500, though, where
   15--15--15 and 15--15--14 are functionally equivalent
-  at Level 50 (both result in MHP of 178) despite
-  respective CPs of 2452 and 2447.
+  at Level 50 (both result in \MHP{} of 178) despite
+  respective \CP{}s of 2452 and 2447.
 It is impossible to distinguish between a Level 16.5 Conkeldurr at
-  3--15--15 or 3--15--14 (134 MHP either way), though
-  the CPs are 1500 and 1497.
+  3--15--15 or 3--15--14 (134 \MHP{} either way), though
+  the \CP{}s are 1500 and 1497.
 In the Ultra League, Conkeldurr wants Level 28 0--15--12 with
-  a CP of 2499.
+  a \CP{} of 2499.
 Take two things away from this:
 \begin{itemize}
 \item The optimal IVs, and even the number of equivalent optimal IVs, can change across evolution.
   This is largely independent of any global fitness function.
 \item Hitting the ceiling does not guarantee optimal IVs for most fitness functions.
-  More generally, under most fitness functions, higher CP does not necessarily imply superior IVs.
-    Gurdurr has numerous solutions yielding 1500 CP (3/2/0@28, for instance, with geometric
+  More generally, under most fitness functions, higher \CP{} does not necessarily imply superior IVs.
+    Gurdurr has numerous solutions yielding 1500 \CP{} (3/2/0@28, for instance, with geometric
     mean 120.015), but 1/15/15@26 beats it at 1496 (121.968).
 \end{itemize}
 There are many fitness functions. In the Gurdurr example given previously, 3--2--0 loses
-    to 1--15--15 at geometric mean, but has an $\mathit{Eff_A}$ of 129.36, comfortably above the latter's 123.29.
- Does this compensate for six fewer hit points (145 vs 139) and lower $\mathit{Eff_D}$ (101.49 vs 96.136)?
+    to 1--15--15 at geometric mean, but has an \Eff{A} of 129.36, comfortably above the latter's 123.29.
+ Does this compensate for six fewer hit points (145 vs 139) and lower \Eff{D} (101.49 vs 96.136)?
  Let's pit them against one another, using Low Kick (Power of 4, neutral type effectiveness, STAB bonus).
  Our Level 28 competitor strikes for six damage with each attack:
     \[ \left\lfloor \frac{129.36 \cdot 4 \cdot 1.2}{101.49} \right\rfloor = \lfloor 6.118 \rfloor = 6 \]
@@ -100,30 +100,30 @@ There are many fitness functions. In the Gurdurr example given previously, 3--2-
  If the attack's Power were 10, both hit for nine damage, and both fall after nine attacks.
 
 \section{Optimal League forms}
-Pokémon GO offers two CP-bounded PvP leagues, the Great League (CP 1500) and
-   the Ultra League (CP 2500).
+Pokémon GO offers two \CP{}-bounded PvP leagues, the Great League (\CP{} 1500) and
+   the Ultra League (\CP{} 2500).
 \autoref{table:cp1500g} lists species' optimal level and IVs for the Great League
-  as evaluated using the geometric mean of $\mathit{Eff_A}$, $\mathit{Eff_D}$, and $MHP$.
+  as evaluated using the geometric mean of \Eff{A}, \Eff{D}, and \MHP{}.
 Species which can't manage a geometric mean of 124.66 have been left out.
 \autoref{table:cp2500g} does the same for the Ultra League, eliding those species which
-  can't hit a $\sqrt[3]{BP}$ of 156.78.
-A few observations from the CP1500 table:
-In general, there is no correlation between $\sqrt[3]{BP}$ and level,
+  can't hit a $\sqrt[3]{\BP\,}$ of 156.78.
+A few observations from the \CP{}1500 table:
+In general, there is no correlation between $\sqrt[3]{\BP\,}$ and level,
   save that everything at the bottom of the list is maxed (15/15/15@50),
-  since many species cannot reach 1500 CP at all.
-The geometric mean ($\sqrt[3]{BP}$) ranges from 51.39 (max Shedinja)
+  since many species cannot reach 1500 \CP{} at all.
+The geometric mean ($\sqrt[3]{\BP\,}$) ranges from 51.39 (max Shedinja)
   to 147.18 (15/15/15@49.5 Chansey).
 There is a strong bimodal preference for IVs: 15/15/15 for level 49.5
   and 50, and otherwise $n$/15/15 where $n < 2$, and $n$ usually equals 0.
-This verifies (not that we had any doubt) that attack is highly overvalued in the CP calculation relative to $\sqrt[3]{BP}$.
+This verifies (not that we had any doubt) that attack is highly overvalued in the \CP{} calculation relative to $\sqrt[3]{\BP\,}$.
 Other IVs usually correspond to low level, powerful species, where a level
-  raises CP by a large amount, leaving more room for beneficial IVs.
-$\mathit{Eff_A}$ ranges from 63.02 (Chansey) to tremendous outlier 254.05 (Deoxys Attack).
-In general, the top positions have relatively low $\mathit{Eff_A}$, rising in an
+  raises \CP{} by a large amount, leaving more room for beneficial IVs.
+\Eff{A} ranges from 63.02 (Chansey) to tremendous outlier 254.05 (Deoxys Attack).
+In general, the top positions have relatively low \Eff{A}, rising in an
   orderly fashion to about 145 as we go down the list.
 At this point, they become more disordered, until falling at the back
   of the list.
-$MHP$ and $\mathit{Eff_D}$ are much less predictable.
+\MHP{} and \Eff{D} are much less predictable.
 \begin{figure}
 \begin{minipage}{0.5\textwidth}\begin{center}
 \includegraphics[width=\textwidth,keepaspectratio]{octave/greninjalevels.png}
@@ -132,17 +132,17 @@ $MHP$ and $\mathit{Eff_D}$ are much less predictable.
 \includegraphics[width=\textwidth,keepaspectratio]{octave/greninjagmeans.png}
 \end{center}\end{minipage}%
 \caption[Contours of optimal Greninja levels]{Contours of optimal Greninja levels and resulting geometric means
-  (X axis is $IV_A$, Y axis is $IV_D + IV_S$).\label{fig:contours}}
+  (X axis is \IV{A}, Y axis is $\IV{D} + \IV{S}$).\label{fig:contours}}
 \end{figure}
 What's more important, IVs or level?
 Given the vast number of 0/15/15 IVs among the optimal sets, it
-  would seem to be $IV_D$ and $IV_S$ (and that it is equally
-  important to minimize $IV_A$).
+  would seem to be \IV{D} and \IV{S} (and that it is equally
+  important to minimize \IV{A}).
 This is true for levels below 30 or so, but more powerful Pokémon
   have optimal configurations below that.
 Among these, we see much more diversity of IVs.
 The IVs are being pushed lower to allow for higher levels.
-This reflects the diminishing returns on CPM as level increases.
+This reflects the diminishing returns on \CPM{} as level increases.
 The real answer is: equal importance until level 30 or so, and IVs beyond that,
   though the Attack component is always less important than level
   (as evidenced by the large number of x/15/15@50 configurations).
@@ -156,24 +156,24 @@ I'm a fan of bringing in powerful Pokémon at low levels; their stats are
   comparable to less powerful Pokémon at higher levels, but they
   generally have more powerful moves.
 One has to be careful choosing, though; most end up woefully underpowered
-  with respect to MHP vs potential MHP (\autoref{fig:maxmhpvsoptmhp}).
+  with respect to \MHP{} vs potential \MHP{} (\autoref{fig:maxmhpvsoptmhp}).
 \begin{figure}
 \includegraphics[width=\textwidth]{octave/maxmhpvsoptmhp.png}
-  \caption{$\frac{BS}{3}$-optimal MHP vs maximum possible MHP.\label{fig:maxmhpvsoptmhp}}
+  \caption{$\frac{\mathit{BS}}{3}$-optimal \MHP{} vs maximum possible \MHP.\label{fig:maxmhpvsoptmhp}}
 \end{figure}
 
 \section{Breakpoints\label{sec:breakpoints}}
 Should you have (or believe you have) a good idea of what you'll be going up against,
  breakpoint analysis is a powerful tool.
-Essentially, we want to model the relationship between two Pokémons' $\mathit{Eff_D}$
- and $\mathit{Eff_A}$.
-Alternately, we want to model damage inflicted against MHP\@.
-Using this information, we can perhaps choose more optimal IVs and levels for a given CP bound.
+Essentially, we want to model the relationship between two Pokémons' \Eff{D}
+ and \Eff{A}.
+Alternately, we want to model damage inflicted against \MHP\@.
+Using this information, we can perhaps choose more optimal IVs and levels for a given \CP{} bound.
 This is only as useful as the accuracy of our information, and how narrow a set of opponents it specifies.
 
 In \autoref{table:bpoints1} and \autoref{table:bpoints2}, we see level 50 Clodsire
   employing two charged attacks against level 50 Sawk.
-Columns correspond to different $IV_A$ for Clodsire, and rows to different $IV_D$ for Sawk.
+Columns correspond to different \IV{A} for Clodsire, and rows to different \IV{D} for Sawk.
 The spread of damage is greater for Earthquake than Megahorn (16 versus 9), a ratio
   of 1.\textoverline{7}, significantly more than the ratio of Earthquake (with STAB)
   to Megahorn (1.2).
@@ -184,7 +184,7 @@ I haven't included a table for fast attack, as it deals damage of 2 for all comb
 \section{Type restrictions\label{sec:typeleagues}}
 A common variation on the usual Leagues is a type restriction.
 The summer of 2025 features the ``Fossil Cup'', wherein all competing
-  Pokémon (in addition to coming in under the CP1500 bound)
+  Pokémon (in addition to coming in under the \CP 1500 bound)
   must include Rock, Steel, or Water in their typing.
 The cover sets of \autoref{sec:coversets} make their return with a vengeance!
 

--- a/006-pgo/bounded.tex
+++ b/006-pgo/bounded.tex
@@ -18,7 +18,7 @@ We then select a team using the strategies of that chapter. Since
 \section{Optimal IVs and Levels under a CP bound}
 We require a fitness function that takes as input a Pokémon's form, level, and IV,
   and emits a comparable output.
-Common functions include CP itself, the arithmetic mean ($\frac{Eff_A +Eff_D + MHP}{3}$),
+Common functions include CP itself, the arithmetic mean ($\frac{\mathit{Eff_A} +\mathit{Eff_D} + MHP}{3}$),
   and the geometric mean ($\sqrt[3]{\mathit{Eff_A} \cdot \mathit{Eff_D} \cdot MHP}$)\footnote{I personally believe the geometric mean to best match Pokémon GO's
   mechanics, but there is no true ``best'' fitness function---optimal IVs are
   dependent upon both the base stats and the opponent.}.

--- a/006-pgo/breakpoints.cpp
+++ b/006-pgo/breakpoints.cpp
@@ -11,7 +11,7 @@ static pmon pm[2];
 static void
 print_dbreak_table(pmon *p, pmon *atk, const attack *a, int tableno){
   printf("\\begin{table}\\setlength{\\tabcolsep}{2pt}\\footnotesize\\centering\\begin{tabular}{rcccccccccccccccc}\n");
-  printf("$IV_D$ & 0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10 & 11 & 12 & 13 & 14 & 15\\\\\n");
+  printf("\\IV{D} & 0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10 & 11 & 12 & 13 & 14 & 15\\\\\n");
   printf("\\Midrule\n");
   int firstd = -1;
   for(int ivd = 0 ; ivd < 16 ; ++ivd){

--- a/006-pgo/dualcharged.cpp
+++ b/006-pgo/dualcharged.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv){
   std::sort(tsets.begin(), tsets.end(), std::greater<typeset>());
   printf("\\begingroup\\footnotesize");
   printf("\\begin{longtable}{crrrrrrrr}\\footnotesize");
-  printf("& -3 & -2 & -1 & 0 & 1 & 2 & ARA & Pop\\\\\\endhead\n");
+  printf("& -3 & -2 & -1 & 0 & 1 & 2 & \\ARA & Pop\\\\\\endhead\n");
   bool grey = true;
   for(const auto &ts : tsets){
     if( (grey = !grey) ){

--- a/006-pgo/dualtypes.cpp
+++ b/006-pgo/dualtypes.cpp
@@ -276,7 +276,7 @@ defensive_summaries_latex(const typing* t){
   const int offset = -3;
   // defensive typing summaries
   printf("\\begin{longtable}{crrrrrrrrr}\n");
-  printf("& -3 & -2 & -1 & 0 & 1 & 2 & DRA & Pop & Page\\\\\n\\Midrule\n");
+  printf("& -3 & -2 & -1 & 0 & 1 & 2 & \\DRA & Pop & Page\\\\\n\\Midrule\n");
   printf("\\endhead\n");
   bool grey = false;
   enum {

--- a/006-pgo/example.tex
+++ b/006-pgo/example.tex
@@ -1,7 +1,7 @@
 \chapter{A worked example of team selection\label{chap:example}}
 
 Let's consider the Fossil Cup of summer 2025, which began and ended while I was writing this book.
-Like the Great League, the Fossil Cup had a CP1500 bound, and further
+Like the Great League, the Fossil Cup had a \CP1500 bound, and further
   restricted participants to those with Rock, Steel, or Water in their typings.
 This limits teams to 51 of the 171 typings (29.8\%): the three monotypes, seventeen dualtypes
  involving Rock, sixteen dualtypes involving Steel (we already counted Rock+Steel), and
@@ -13,7 +13,7 @@ One hundred matches in, I was doing alright (despite far from optimal IVs)
   with the following team, assembled largely off vibes:
 \begin{center}
   \begin{tabular}{llrrrr}
-    Pokémon & IV@Level & $\mathit{Eff_A}$ & $\mathit{Eff_D}$ & MHP & $\sqrt[3]{BP}$\\
+    Pokémon & IV@Level & \Eff{A} & \Eff{D} & \MHP & $\sqrt[3]{\BP\,}$\\
     \Midrule
     Greninja & \ivlev{15}{14}{12}{20} & 142.18 & 99.17 & 112 & 115.27 \\
     Magcargo & \ivlev{15}{13}{12}{32.5} & 115.01 & 152.35 & 111 & 124.82 \\
@@ -46,11 +46,11 @@ I hardly needed more Water strength, so I threw on Body Slam for opponents stron
 
 \section{Boosting the numbers}
 Without changing my choice of species, the following configurations are desirable
-  in the context of optimizing for $\sqrt[3]{BP}$\footnote{If we optimized for $\frac{BS}{3}$,
+  in the context of optimizing for $\sqrt[3]{\mathit{\BP\,}}$\footnote{If we optimized for $\frac{\mathit{BS}}{3}$,
    as done in \autoref{chap:optimal}, we'd see different ideals.}:
 \begin{center}
 \begin{tabular}{llrrrr}
-  Pokémon & IV@Level & $\mathit{Eff_A}$ & $\mathit{Eff_D}$ & MHP & $\sqrt[3]{BP}$\\
+  Pokémon & IV@Level & \Eff{A} & \Eff{D} & \MHP & $\sqrt[3]{\BP\,}$\\
   \Midrule
   Greninja &\ivlev{3}{15}{12}{20} & 138.35 & 102.23 & 115 & 117.60\\
   Magcargo &\ivlev{0}{15}{14}{38.5} & 108.67 & 161.05 & 118 & 127.34\\

--- a/006-pgo/example.tex
+++ b/006-pgo/example.tex
@@ -60,7 +60,7 @@ Without changing my choice of species, the following configurations are desirabl
 Of course, it is not generally possible to change IVs.
 Even if I could, the benefits would be meager: a 2.02\% increase for Greninja,
   2.02\% to Magcargo, and a mere 0.73\% for Gastrodon, all of it coming
-  in defense and HP at the expense of a bit of attack.
+  in defense and \HP{} at the expense of a bit of attack.
 The means themselves are unspectacular, but not bad: Gastrodon and Magcargo are up there
   in the thick of things, and Greninja is blasting away with that Hydro Cannon every nine turns.
 
@@ -83,7 +83,7 @@ As noted in \autoref{sec:typeleagues}, there exist two minimal coverings of the 
  Bug, Dragon, Fire, Grass, Ground, Rock\\
 \end{tabular}
 \end{center}
-Bug isn't known for high PPT\@. Infestation manages two while achieving four EPT,
+Bug isn't known for high \PPT{}\@. Infestation manages two while achieving four \EPT{},
  but requires three turns. Bug Bite does three on both in a single turn.
 
 Grass and Ground make up a cover of the core types, as do Fighting and Grass.
@@ -149,13 +149,13 @@ Magcargo could handle Grass (especially Steel+Grass Ferrothorn), but
  without switch advantage, there was usually a Water Pokémon to come
  in and put out its fire.
 Looking at the three Pokémon, there are no Grass attacks to learn.
-Despite that awesome 4.67 EPT from Water Shuriken, Greninja was probably
+Despite that awesome 4.67 \EPT{} from Water Shuriken, Greninja was probably
   the weakest link due to its lack of bulk.
 If it goes in with shield disadvantage, it has a bad time.
 No other fast attack achieves 4.67, but we get 4.5 from several---Psycho
   Cut, Fairy Wind, Poison Sting, Thunder Shock, and Karate Chop,
   all of which are fewer turns than Shuriken's 3.
-Karate Chop (2.5) and Hex or Rollout (2.33) even beat its PPT of 2.
+Karate Chop (2.5) and Hex or Rollout (2.33) even beat its \PPT{} of 2.
 The first two don't seem available from any useful Pokémon, but
   Rollout is available from Blastoise, and we'd even be able to
   keep Hydro Cannon!

--- a/006-pgo/example.tex
+++ b/006-pgo/example.tex
@@ -13,7 +13,7 @@ One hundred matches in, I was doing alright (despite far from optimal IVs)
   with the following team, assembled largely off vibes:
 \begin{center}
   \begin{tabular}{llrrrr}
-    Pokémon & IV@Level & $Eff_A$ & $Eff_D$ & MHP & $\sqrt[3]{BP}$\\
+    Pokémon & IV@Level & $\mathit{Eff_A}$ & $\mathit{Eff_D}$ & MHP & $\sqrt[3]{BP}$\\
     \Midrule
     Greninja & \ivlev{15}{14}{12}{20} & 142.18 & 99.17 & 112 & 115.27 \\
     Magcargo & \ivlev{15}{13}{12}{32.5} & 115.01 & 152.35 & 111 & 124.82 \\
@@ -50,7 +50,7 @@ Without changing my choice of species, the following configurations are desirabl
    as done in \autoref{chap:optimal}, we'd see different ideals.}:
 \begin{center}
 \begin{tabular}{llrrrr}
-  Pokémon & IV@Level & $Eff_A$ & $Eff_D$ & MHP & $\sqrt[3]{BP}$\\
+  Pokémon & IV@Level & $\mathit{Eff_A}$ & $\mathit{Eff_D}$ & MHP & $\sqrt[3]{BP}$\\
   \Midrule
   Greninja &\ivlev{3}{15}{12}{20} & 138.35 & 102.23 & 115 & 117.60\\
   Magcargo &\ivlev{0}{15}{14}{38.5} & 108.67 & 161.05 & 118 & 127.34\\

--- a/006-pgo/fastattacks.cpp
+++ b/006-pgo/fastattacks.cpp
@@ -20,7 +20,7 @@ void print_latex_table(const attack* as, unsigned ccount){
   printf("\\begin{center}\n");
   printf("\\footnotesize\n");
   printf("\\begin{longtable}{lrrrrrrrrr}\n");
-  printf("Attack & P & $\\cdot\\frac{6}{5}$ & E & T & PPT & $\\cdot\\frac{6}{5}$ & EPT & Pop\\\\\n");
+  printf("Attack & P & $\\cdot\\frac{6}{5}$ & E & T & \\PPT & $\\cdot\\frac{6}{5}$ & \\EPT & Pop\\\\\n");
   printf("\\Midrule\n");
   printf("\\endhead\n");
   for(unsigned c = 0 ; c < ccount ; ++c){
@@ -37,7 +37,7 @@ void print_latex_table(const attack* as, unsigned ccount){
            (a->powertrain * 6.0) / (a->turns * 5.0),
            a->energytrain / (float)a->turns, learner_count(a));
   }
-  printf("\\caption{Fast attacks, PPT, and EPT (3x3 battles)\\label{table:fastattacks}}\n");
+  printf("\\caption{Fast attacks, \\PPT, and \\EPT (3x3 battles)\\label{table:fastattacks}}\n");
   printf("\\end{longtable}\n");
   printf("\\end{center}\n");
 }

--- a/006-pgo/friends.tex
+++ b/006-pgo/friends.tex
@@ -143,15 +143,15 @@ Level & Hearts & Perks\\
 Good & 1 & Adventuring Buddy, Readable Mood\\
 Great & 70 & Catch Assist, Finding Presents\\
 Ultra & 150 & Finding Souvenirs, Finding Locations\\
-Best & 300 & CPM boost, Ribbon\\
+Best & 300 & \CPM{} boost, Ribbon\\
 \end{tabular}
 \caption{Buddy level requirements and perks\label{table:buddy}}
 \end{table}
-The CPM boost only applies while the Pokémon is designated Buddy,
+The \CPM{} boost only applies while the Pokémon is designated Buddy,
   and is worth two halflevels (\autoref{sec:cpm}).
 A level 20.5 Best Buddy will thus enjoy \Eff{A}, \Eff{D}, and \Eff{S} values
   as if it were level 21.5 (\autoref{sec:effectivestats}).
 This holds true even at levels 49.5 and 50: the CPMs for these unattainable
   pseudolevels 50.5 and 51 are 0.8428 and 0.8453.
 This boost \textit{is} carried into League 3x3 play (\autoref{subsec:league}),
-  and counts against any CP bound.
+  and counts against any \CP{} bound.

--- a/006-pgo/friends.tex
+++ b/006-pgo/friends.tex
@@ -149,7 +149,7 @@ Best & 300 & CPM boost, Ribbon\\
 \end{table}
 The CPM boost only applies while the Pokémon is designated Buddy,
   and is worth two halflevels (\autoref{sec:cpm}).
-A level 20.5 Best Buddy will thus enjoy $\mathit{Eff_A}$, $\mathit{Eff_D}$, and $\mathit{Eff_S}$ values
+A level 20.5 Best Buddy will thus enjoy \Eff{A}, \Eff{D}, and \Eff{S} values
   as if it were level 21.5 (\autoref{sec:effectivestats}).
 This holds true even at levels 49.5 and 50: the CPMs for these unattainable
   pseudolevels 50.5 and 51 are 0.8428 and 0.8453.

--- a/006-pgo/friends.tex
+++ b/006-pgo/friends.tex
@@ -149,7 +149,7 @@ Best & 300 & CPM boost, Ribbon\\
 \end{table}
 The CPM boost only applies while the Pokémon is designated Buddy,
   and is worth two halflevels (\autoref{sec:cpm}).
-A level 20.5 Best Buddy will thus enjoy $Eff_A$, $Eff_D$, and $Eff_S$ values
+A level 20.5 Best Buddy will thus enjoy $\mathit{Eff_A}$, $\mathit{Eff_D}$, and $\mathit{Eff_S}$ values
   as if it were level 21.5 (\autoref{sec:effectivestats}).
 This holds true even at levels 49.5 and 50: the CPMs for these unattainable
   pseudolevels 50.5 and 51 are 0.8428 and 0.8453.

--- a/006-pgo/list.tex
+++ b/006-pgo/list.tex
@@ -22,10 +22,10 @@ nick black (\href{mailto:nickblack@linux.com}{nickblack@linux.com}, \href{https:
 
 A cycle is the minimum number of fast attacks sufficient to launch the charged attack, plus the charged attack itself.
 The configuration is that which maximizes the geometric mean of attack, defense, and MHP, where attack and defense are STA and DEF, augmented by $IV_A$ and $IV_D$ respectively, and scaled by CPM.
-$Eff_D$ is defense as defined above, scaled by half of any buff the charged attack has on the user's defense.
-DR is the geometric mean of $Eff_D$ and MHP.
-$Eff_A$ is attack as defined above, scaled by half of any buff the charged attack has on the user's attack.
-DI is the geometric mean of $Eff_A$ and attack power over a cycle,
+\Eff{D} is defense as defined above, scaled by half of any buff the charged attack has on the user's defense.
+DR is the geometric mean of \Eff{D} and MHP.
+\Eff{A} is attack as defined above, scaled by half of any buff the charged attack has on the user's attack.
+DI is the geometric mean of \Eff{A} and attack power over a cycle,
 \textit{e} is the energy left after the first cycle, and is not further incorporated (but probably should be).
 \%c is the percentage of the first cycle's power delivered by the charged attack, and is not further incorporated.
 \textbf{Dank} is the product of the squares of DI and DR divided by the square of turns in the first cycle, divided by 10,000; it values speed more than most such stats.

--- a/006-pgo/ooo.tex
+++ b/006-pgo/ooo.tex
@@ -61,5 +61,5 @@ Transfer most of what you capture, keeping only quality species with decent IVs 
 As you develop quality Pokémon, give veterans the thanks they deserve: a quick trip to the Professor!
 Savor the Candy through which they serve you even in death.
 
-Trainers interested in League play will want a similar (but smaller) set of Pokémon chosen for each League's CP limits.
+Trainers interested in League play will want a similar (but smaller) set of Pokémon chosen for each League's \CP{} limits.
 Read on\ldots

--- a/006-pgo/optimal.tex
+++ b/006-pgo/optimal.tex
@@ -1,7 +1,7 @@
 \chapter{Optimal CP-bound configurations\label{chap:optimal}}
 \section{CP1500 bound sorted by $\frac{BS}{3}$ (Great League)\label{sec:cp1500a}}
 Forms\footnote{Forms disallowed in League play are not listed.} are sorted by $\frac{BS}{3}$,
-  the arithmetic mean of $Eff_A$, $Eff_D$, and MHP\@.
+  the arithmetic mean of $\mathit{Eff_A}$, $\mathit{Eff_D}$, and MHP\@.
 This metric usually distinguishes between standard and Shadow forms (the geometric mean is always unchanged).
 I include $\sqrt[3]{BP}$ and even CP\@.
 These rankings \textit{do not} imply that a higher $\sqrt[3]{BP}$ or $\frac{BS}{3}$

--- a/006-pgo/optimal.tex
+++ b/006-pgo/optimal.tex
@@ -1,37 +1,42 @@
-\chapter{Optimal CP-bound configurations\label{chap:optimal}}
-\section{CP1500 bound sorted by $\frac{BS}{3}$ (Great League)\label{sec:cp1500a}}
-Forms\footnote{Forms disallowed in League play are not listed.} are sorted by $\frac{BS}{3}$,
-  the arithmetic mean of $\mathit{Eff_A}$, $\mathit{Eff_D}$, and MHP\@.
+\chapter{Optimal $\mathbfit{C\kern -1pt P}$-bound configurations\label{chap:optimal}}
+\section[\CP1500 bound sorted by $\frac{\mathit{BS}}{3}$ (Great League)]%
+{$\mathbfit{C\kern -1ptP}$\,1500 bound sorted by $\frac{\mathbfit{BS}}{\mathbf3}$ (Great League)\label{sec:cp1500a}}
+
+Forms\footnote{Forms disallowed in League play are not listed.} are sorted by $\frac{\mathit{BS}}{3}$,
+  the arithmetic mean of \Eff{A}, \Eff{D}, and \MHP\@.
 This metric usually distinguishes between standard and Shadow forms (the geometric mean is always unchanged).
-I include $\sqrt[3]{BP}$ and even CP\@.
-These rankings \textit{do not} imply that a higher $\sqrt[3]{BP}$ or $\frac{BS}{3}$
+I include $\sqrt[3]{\BP\,}$ and even \CP\@.
+These rankings \textit{do not} imply that a higher $\sqrt[3]{\BP\,}$ or $\frac{\mathit{BS}}{3}$
   will defeat a lower one.
 Other issues---type effectiveness, attack choice, strategy---are usually more important.
-Multiple sets of IVs and levels can score equally due to the discrete nature of MHP\@.
+Multiple sets of IVs and levels can score equally due to the discrete nature of \MHP\@.
 In this case, all optimal sets are listed.
 
 $A\%$ is the optimal configuration's advantage in terms of $\frac{BS}{3}$
   over the pessimal ``reasonable'' configuration, i.e. some IV
-  and the highest level attainable given the CP bound.
-For CP1500 (\autoref{table:cp1500a}, \autoref{table:cp1500g}), when a form can max out, i.e.\ is not restricted by the CP bound,
+  and the highest level attainable given the \CP{} bound.
+For \CP1500 (\autoref{table:cp1500a}, \autoref{table:cp1500g}), when a form can max out, i.e.\ is not restricted by the \CP{} bound,
   the maximum advantage tends to be 10\%--25\%, with a few outliers around 50\%.
 It otherwise quickly drops to 4\% or less.
-In CP2500 (\autoref{table:cp2500a}, \autoref{table:cp2500g}), the advantage available from IVs is even smaller, as we would expect.
+In \CP2500 (\autoref{table:cp2500a}, \autoref{table:cp2500g}), the advantage available from IVs is even smaller, as we would expect.
 For maxed out Pokémon, A\% ranges from 6\%--11\%, increasing as we go down the table.
 It is otherwise generally less than 12\%.
-These numbers are larger using $\frac{BS}{3}$ than $\sqrt[3]{BP}$.
+These numbers are larger using $\frac{\mathit{BS}}{3}$ than $\sqrt[3]{\BP}$.
 With the latter, maximum advantages are contained within 12\%--15\%, and everyone else is below 3\%.
 \input{out/cp1500a}
-\section{CP2500 bound sorted by $\frac{BS}{3}$ (Ultra League)}
+\section[\CP2500 bound sorted by $\frac{\mathit{BS}}{3}$ (Ultra League)]%
+{$\mathbfit{C\kern -1ptP}$\,2500 bound sorted by $\frac{\mathbfit{BS}}{\mathbf3}$ (Ultra League)}
 See \autoref{sec:cp1500a} for important notes.
 \input{out/cp2500a}
-\section{CP1500 bound sorted by $\sqrt[3]{BP}$ (Great League)\label{sec:cp1500g}}
+\section[\CP1500 bound sorted by \protect{$\sqrt[3]{\BP\,}$} (Great League)]%
+{$\mathbfit{C\kern -1ptP}$\,1500 bound sorted by $\sqrt[3]{\mathbfit{BP}\;}$ (Great League)\label{sec:cp1500g}}
 See \autoref{sec:cp1500a} for important notes.
-This table uses the geometric mean $\sqrt[3]{BP}$ instead of the arithmetic mean.
+This table uses the geometric mean $\sqrt[3]{\BP\,}$ instead of the arithmetic mean.
 Since Shadow forms don't change under the geometric mean, they have been elided.
 \input{out/cp1500g}
-\section{CP2500 bound sorted by $\sqrt[3]{BP}$ (Ultra League)\label{sec:cp2500g}}
+\section[\CP2500 bound sorted by \protect{$\sqrt[3]{\BP\,}$} (Ultra League)]%
+{$\mathbfit{C\kern -1ptP}$\,2500 bound sorted by $\sqrt[3]{\mathbfit{BP}\;}$ (Ultra League)\label{sec:cp2500g}}
 See \autoref{sec:cp1500g} for important notes.
-This table uses the geometric mean $\sqrt[3]{BP}$ instead of the arithmetic mean.
+This table uses the geometric mean $\sqrt[3]{\BP{}\,}$ instead of the arithmetic mean.
 Since Shadow forms don't change under the geometric mean, they have been elided.
 \input{out/cp2500g}

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -93,6 +93,7 @@
 % acronyms
 \newcommand*{\DRA}{\mbox{$\mathit{DRA}$}}
 \newcommand*{\CPM}{\mbox{$\mathit{CPM}$}}
+\newcommand*{\ARA}{\mbox{$\mathit{ARA}$}}
 
 \chapterstyle{crosshead}
 

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -93,18 +93,18 @@
 \makeatother
 
 % acronyms
-\newcommand*{\DRA}{\mbox{$\mathit{DRA}$}}
-\newcommand*{\CPM}{\mbox{$\mathit{CPM}$}}
-\newcommand*{\ARA}{\mbox{$\mathit{ARA}$}}
-\newcommand*{\MHP}{\mbox{$\mathit{MHP}$}}
-\newcommand*{\EPT}{\mbox{$\mathit{EPT}$}}
-\newcommand*{\PPT}{\mbox{$\mathit{PPT}$}}
-\newcommand*{\HP}{\mbox{$\mathit{HP}$}}
-\newcommand*{\CP}{\mbox{$\mathit{CP}$}}
-\newcommand*{\BP}{\mbox{$\mathit{BP}$}}
-\newcommand*{\Eff}[1]{\mbox{$\mathit{Eff_\mathrm{#1}}$}}
-\newcommand*{\Mod}[1]{\mbox{$\mathit{Mod_\mathrm{#1}}$}}
-\newcommand*{\IV}[1]{\mbox{$\mathit{IV_\mathrm{#1}}$}}
+\newcommand*{\DRA}{\mbox{$\mathrm{DRA}$}}
+\newcommand*{\CPM}{\mbox{$\mathrm{CPM}$}}
+\newcommand*{\ARA}{\mbox{$\mathrm{ARA}$}}
+\newcommand*{\MHP}{\mbox{$\mathrm{MHP}$}}
+\newcommand*{\EPT}{\mbox{$\mathrm{EPT}$}}
+\newcommand*{\PPT}{\mbox{$\mathrm{PPT}$}}
+\newcommand*{\HP}{\mbox{$\mathrm{HP}$}}
+\newcommand*{\CP}{\mbox{$\mathrm{CP}$}}
+\newcommand*{\BP}{\mbox{$\mathrm{BP}$}}
+\newcommand*{\Eff}[1]{\mbox{$\mathrm{Eff_{#1}}$}}
+\newcommand*{\Mod}[1]{\mbox{$\mathrm{Mod_{#1}}$}}
+\newcommand*{\IV}[1]{\mbox{$\mathrm{IV_{#1}}$}}
 
 \chapterstyle{crosshead}
 

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -36,7 +36,9 @@
 \setmainfont{Gentium Book}
 \setdefaultlanguage{american}
 \setmathrm{lmroman10-regular.otf}[
-  ItalicFont = lmroman10-italic.otf]
+  ItalicFont = lmroman10-italic.otf,
+  BoldItalicFont = lmroman10-bolditalic.otf,
+  BoldFont = lmroman10-bold.otf]
 \newfontfamily\japanesefont[Script=CJK]{Noto Serif CJK JP}
 \newfontfamily\chinesefont[Script=CJK]{Noto Serif CJK SC}
 \setotherlanguages{japanese,chinese}
@@ -95,6 +97,8 @@
 \newcommand*{\CPM}{\mbox{$\mathit{CPM}$}}
 \newcommand*{\ARA}{\mbox{$\mathit{ARA}$}}
 \newcommand*{\MHP}{\mbox{$\mathit{MHP}$}}
+\newcommand*{\EPT}{\mbox{$\mathit{EPT}$}}
+\newcommand*{\PPT}{\mbox{$\mathit{PPT}$}}
 \newcommand*{\HP}{\mbox{$\mathit{HP}$}}
 \newcommand*{\CP}{\mbox{$\mathit{CP}$}}
 \newcommand*{\BP}{\mbox{$\mathit{BP}$}}
@@ -215,15 +219,15 @@ Forms are sorted by typing, and within typing by Pokédex number.
 The title displays the form name on the left.
 If a Shiny form exists, the shiny icon (\calign{\includegraphics[height=1em,keepaspectratio]{images/shiny.png}}) is displayed.
 The form's base ATK, DEF, and STA appear on the right, followed by the arithmetic and geometric means
- ($\frac{BS}{3}$ and $\sqrt[3]{BP}$).
+ ($\frac{BS}{3}$ and $\sqrt[3]{\BP\,}$).
 The colors of the title bar indicate the typing.
 To the right of a picture is a table of fast and charged attacks.
 I have factored STAB into applicable attacks.
-Fast attacks show turns, power, energy generated, PPT, and EPT\@.
+Fast attacks show turns, power, energy generated, \PPT{}, and \EPT{}\@.
 Charged attacks show power, energy consumed, and PPE\@.
 Attacks in italics cannot be acquired without an Elite TM or special circumstances.
 Type, cost group, weather boosting, and existence of a Shiny form are indicated with icons.
-The optimal configurations for CP2500 and CP1500-bounded play are specified below the attack table.
+The optimal configurations for \CP2500 and \CP1500-bounded play are specified below the attack table.
 The last line of the card shows cost group, generation, and region on the left,
  and evolutionary line on the right.
 Finally, if there is a Shadow form, that is indicated, along with the same stats
@@ -258,10 +262,10 @@ CG 4 Gen X Atlantic\hfill{}Columbia → \textbf{Challenger} → Discovery
 \tcbsubtitle[before skip=1pt,bottomrule=0pt]{Shadow OV-099 Challenger\hfill{240 100 100 146.67 133.89}}
 \end{speciesbox}
 \bigskip\noindent{}We see here that OV-099 Challenger has Ghost+Flying typing, with base ATK, DEF, and STA
-of 200, 120, and 100, respectively. Its $\frac{BS}{3}$ is 140, and its $\sqrt[3]{BP}$ is 133.89.
+of 200, 120, and 100, respectively. Its $\frac{BS}{3}$ is 140, and its $\sqrt[3]{\BP\,}$ is 133.89.
 It has a Shadow form, but not a Shiny form. The Shadow form has higher ATK and lower DEF, changing
-its $\frac{BS}{3}$ to 146.67. Its optimal configuration for a CP1500 bound is 0/14/1 at level 42.5.
-It is poorly suited for CP2500 bounds and liftoffs in low temperatures.
+its $\frac{BS}{3}$ to 146.67. Its optimal configuration for a \CP1500 bound is 0/14/1 at level 42.5.
+It is poorly suited for \CP2500 bounds and liftoffs in low temperatures.
 \clearpage
 \input{out/species}
 \vfill\includegraphics[width=\linewidth,keepaspectratio]{images/carnivine.png}\vfill
@@ -273,7 +277,7 @@ Pokémon in italics will \textit{not} have STAB with the attack.
 Pokémon in boldface require an Elite TM (or special circumstances) to acquire the move.
 Attack cards display Nx1 stats in the middle of the title, and 3x3 stats on the right.
 \section{Fast attacks\label{sec:usersfast}}
-Fast attacks are sorted by type, then duration, then by the product of PPT and EPT\@.
+Fast attacks are sorted by type, then duration, then by the product of \PPT{} and \EPT{}\@.
 \input{out/fastusers}
 \section{Charged attacks\label{sec:userscharged}}
 Charged attacks are sorted by type, then PPE\@.

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -96,8 +96,10 @@
 \newcommand*{\ARA}{\mbox{$\mathit{ARA}$}}
 \newcommand*{\MHP}{\mbox{$\mathit{MHP}$}}
 \newcommand*{\HP}{\mbox{$\mathit{HP}$}}
+\newcommand*{\CP}{\mbox{$\mathit{CP}$}}
 \newcommand*{\Eff}[1]{\mbox{$\mathit{Eff_\mathrm{#1}}$}}
 \newcommand*{\Mod}[1]{\mbox{$\mathit{Mod_\mathrm{#1}}$}}
+\newcommand*{\IV}[1]{\mbox{$\mathit{IV_\mathrm{#1}}$}}
 
 \chapterstyle{crosshead}
 

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -97,6 +97,7 @@
 \newcommand*{\MHP}{\mbox{$\mathit{MHP}$}}
 \newcommand*{\HP}{\mbox{$\mathit{HP}$}}
 \newcommand*{\CP}{\mbox{$\mathit{CP}$}}
+\newcommand*{\BP}{\mbox{$\mathit{BP}$}}
 \newcommand*{\Eff}[1]{\mbox{$\mathit{Eff_\mathrm{#1}}$}}
 \newcommand*{\Mod}[1]{\mbox{$\mathit{Mod_\mathrm{#1}}$}}
 \newcommand*{\IV}[1]{\mbox{$\mathit{IV_\mathrm{#1}}$}}

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -35,6 +35,8 @@
 \setsansfont{Kanit}
 \setmainfont{Gentium Book}
 \setdefaultlanguage{american}
+\setmathrm{lmroman10-regular.otf}[
+  ItalicFont = lmroman10-italic.otf]
 \newfontfamily\japanesefont[Script=CJK]{Noto Serif CJK JP}
 \newfontfamily\chinesefont[Script=CJK]{Noto Serif CJK SC}
 \setotherlanguages{japanese,chinese}

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -11,6 +11,8 @@
 \usepackage{bookmark}
 \usepackage{transparent}
 \usepackage[svgnames,HSB,table]{xcolor}
+\selectcolormodel{natural}
+\usepackage{ninecolors}
 \selectcolormodel{rgb}
 \usepackage[labelfont=bf]{caption} % for \captionsetup
 \usepackage{polyglossia}

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -94,6 +94,10 @@
 \newcommand*{\DRA}{\mbox{$\mathit{DRA}$}}
 \newcommand*{\CPM}{\mbox{$\mathit{CPM}$}}
 \newcommand*{\ARA}{\mbox{$\mathit{ARA}$}}
+\newcommand*{\MHP}{\mbox{$\mathit{MHP}$}}
+\newcommand*{\HP}{\mbox{$\mathit{HP}$}}
+\newcommand*{\Eff}[1]{\mbox{$\mathit{Eff_\mathrm{#1}}$}}
+\newcommand*{\Mod}[1]{\mbox{$\mathit{Mod_\mathrm{#1}}$}}
 
 \chapterstyle{crosshead}
 

--- a/006-pgo/pgo.tex
+++ b/006-pgo/pgo.tex
@@ -90,6 +90,10 @@
 \newcommand*{\textoverline}[1]{$\overline{\hbox{#1}}\m@th$}
 \makeatother
 
+% acronyms
+\newcommand*{\DRA}{\mbox{$\mathit{DRA}$}}
+\newcommand*{\CPM}{\mbox{$\mathit{CPM}$}}
+
 \chapterstyle{crosshead}
 
 \setminted{fontsize=\scriptsize}

--- a/006-pgo/pgotypes.cpp
+++ b/006-pgo/pgotypes.cpp
@@ -1192,6 +1192,15 @@ type_effectiveness_mult(int te){
   return pow16[te + 3];
 }
 
+static inline float
+type_effectiveness_mult(int te){
+  if(te < -3 || te > 2){
+    throw std::invalid_argument("bad type effectiveness");
+  }
+  static const float pow16[6] = { 0.244, 0.390625, 0.625, 1, 1.6, 2.56 };
+  return pow16[te + 3];
+}
+
 // calculate type relation of at on dt0 + dt1
 static inline float
 type_effectiveness(pgo_types_e at, pgo_types_e dt0, pgo_types_e dt1){

--- a/006-pgo/pgotypes.cpp
+++ b/006-pgo/pgotypes.cpp
@@ -1192,15 +1192,6 @@ type_effectiveness_mult(int te){
   return pow16[te + 3];
 }
 
-static inline float
-type_effectiveness_mult(int te){
-  if(te < -3 || te > 2){
-    throw std::invalid_argument("bad type effectiveness");
-  }
-  static const float pow16[6] = { 0.244, 0.390625, 0.625, 1, 1.6, 2.56 };
-  return pow16[te + 3];
-}
-
 // calculate type relation of at on dt0 + dt1
 static inline float
 type_effectiveness(pgo_types_e at, pgo_types_e dt0, pgo_types_e dt1){

--- a/006-pgo/pokémon.tex
+++ b/006-pgo/pokémon.tex
@@ -239,11 +239,11 @@ MHP is defined such that it is always an integer not less than ten:
  \mathit{Eff_S} &= \mathit{Mod_S} \cdot CPM \\
  MHP &= \min{10, \lfloor \mathit{Eff_S} \rfloor}
 \end{align*}
-Multiplying $Mod_S$ by CPM yields $Eff_{ARaw}$, used to determine charged move priority (\autoref{sec:3x3}).
+Multiplying \Mod{S} by CPM yields \Eff{ARaw}, used to determine charged move priority (\autoref{sec:3x3}).
 $M_{Shadow}$ is $\frac{6}{5}$ if the Pokémon is a Shadow Pokémon, and 1 otherwise.
-Multiplying $Eff_{ARaw}$ by $M_{Shadow}$ yields $Eff_A$.
-Multiplying $Mod_D$ by CPM and dividing by $M_{Shadow}$ gives us $Eff_D$.
-This manifests a 20\% bonus to $Eff_A$ and a 16.7\% penalty to $Eff_D$.
+Multiplying \Eff{ARaw} by $M_{Shadow}$ yields \Eff{A}.
+Multiplying \Mod{D} by CPM and dividing by $M_{Shadow}$ gives us \Eff{D}.
+This manifests a 20\% bonus to \Eff{A} and a 16.7\% penalty to \Eff{D}.
 \begin{align*}
   Eff_{ARaw} &= Mod_A \cdot CPM\\
   Eff_A &= Eff_{ARaw} \cdot M_{Shadow} \\

--- a/006-pgo/pokémon.tex
+++ b/006-pgo/pokémon.tex
@@ -87,9 +87,9 @@ A Pokémon rated 4 has an IV of 15/15/15, and is colloquially known as a ``hundo
 Such Pokémon have their own Pokédex (\autoref{sec:dexen})\footnote{A Pokémon with an IV of 0/0/0
  is colloquially known as a ``nundo'' or ``0\%er''. They have no unique Pokédex, because they are worthless pieces of shit,
   and don't let anyone tell you otherwise. Consult \autoref{chap:optimal} to see that 0/0/0 is never an optimal IV.}.
-While 15/15/15 is generally the optimal IV, this is not always true in CP-bounded
+While 15/15/15 is generally the optimal IV, this is not always true in \CP-bounded
   competition; see \autoref{chap:bounded} for more information,
-  and \autoref{chap:optimal} for tables of optimal IVs under different CP bounds.
+  and \autoref{chap:optimal} for tables of optimal IVs under different \CP{} bounds.
 \begin{table}
 \centering
 \begin{tabular}{ll}
@@ -115,11 +115,11 @@ At the time of this writing, Gold Bottle Caps have been available only through p
 
 \section{Generation of IV and level\label{sec:ivgeneration}}
 IVs and levels are generated when the Pokémon is ``created'', not when it is captured.
-It is thus possible to glean information from the CP displayed for a Pokémon;
+It is thus possible to glean information from the \CP{} displayed for a Pokémon;
   one can sometimes even uniquely determine the IV\@.
-The equation for CP is provided in \autoref{chap:unbounded}; reverse it and
+The equation for \CP{} is provided in \autoref{chap:unbounded}; reverse it and
   use \autoref{table:cpm} plus the base stats of the species to determine
-  the set of IV+level pairs yielding that CP\@.
+  the set of IV+level pairs yielding that \CP\@.
 Various applications and websites can perform this analysis automatically.
 Depending on the situation, there might be a floor for IVs.
 Beyond that, they are uniformly randomly generated.
@@ -168,9 +168,9 @@ These values are used as inputs to battle mechanics.
 First, sum the Species's ATK, DEF, and STA with the Pokémon's
 IVs to generate \Mod{A}, \Mod{D}, and \Mod{S}:
 \begin{align*}
- \Mod{A} &= \mathit{ATK} + \mathit{IV_\mathrm{A}} \\
- \Mod{D} &= \mathit{DEF} + \mathit{IV_\mathrm{D}} \\
- \Mod{S} &= \mathit{STA} + \mathit{IV_\mathrm{S}}
+ \Mod{A} &= \mathit{ATK} + \mathit{\IV{A}} \\
+ \Mod{D} &= \mathit{DEF} + \mathit{\IV{D}} \\
+ \Mod{S} &= \mathit{STA} + \mathit{\IV{S}}
 \end{align*}
 These are typically scaled by the Pokémon's Combat Power Multiplier.
 \section{Combat Power Multiplier\label{sec:cpm}}

--- a/006-pgo/pokémon.tex
+++ b/006-pgo/pokémon.tex
@@ -236,8 +236,8 @@ Hit Points are persistent across Raids, Max Battles, and Team Rocket encounters,
  than those with Team Rocket) always start with full HP.}.
 MHP is defined such that it is always an integer not less than ten:
 \begin{align*}
- Eff_S &= Mod_S \cdot CPM \\
- MHP &= \min{10, \lfloor Eff_S \rfloor}
+ \mathit{Eff_S} &= \mathit{Mod_S} \cdot CPM \\
+ MHP &= \min{10, \lfloor \mathit{Eff_S} \rfloor}
 \end{align*}
 Multiplying $Mod_S$ by CPM yields $Eff_{ARaw}$, used to determine charged move priority (\autoref{sec:3x3}).
 $M_{Shadow}$ is $\frac{6}{5}$ if the Pokémon is a Shadow Pokémon, and 1 otherwise.

--- a/006-pgo/pokémon.tex
+++ b/006-pgo/pokémon.tex
@@ -1,17 +1,17 @@
 \chapter{Pokémon\label{chap:pokemon}}
 For purposes of battle\footnote{Attributes not directly relevant to battle include height, weight, region,
 generation, Shiny status, Purified status, Lucky status, Legendary status, Mythological status, spawn
-reason, capture method, capture location, and capture time.}, a Pokémon $P$ is defined as having:
+reason, capture method, capture location, and capture time.}, a Pokémon $P$\, is defined as having:
 \begin{itemize}
 \item A species and form (and thus a typing and base stats)
 \item An Individual Vector (IV) (\autoref{sec:ivs}) and level (\autoref{sec:plevel})
 \item A set of two or three attacks, one of which is a fast attack
 \item Modifiers to attack and defense due charged attacks' stat effects (\autoref{sec:buffs})
 \item Shadow status, or the absence thereof
-\item Some number of hit points not exceeding MHP
+\item Some number of hit points not exceeding \MHP
 \end{itemize}
 Hit Points are carried across PvE battles (including encounters with
-  Team GO Rocket and Gym battles), but Trainer Battles always start with full HP\@.
+  Team GO Rocket and Gym battles), but Trainer Battles always start with full \HP\@.
 A Pokémon with zero hit points has ``fainted''.
 Fainted Pokémon cannot be used in battles of any kind, nor can they be left in
  Power Stops (see \autoref{sec:maxbattles}).
@@ -53,11 +53,11 @@ Level &
 \caption{Power-up costs for Pokémon levels\label{table:powerups}}
 \end{table}
 An increase in level improves the Pokémon's attack and defense, and
-  will sometimes increase MHP\@.
+  will sometimes increase \MHP\@.
 See \autoref{sec:staticstats} for a quantitative treatment.
 
-Powering up a fainted Pokémon will revive it, but with minimal HP\@:
-\[ HP = \min{1, MHP_{New} - MHP_{Old} } \]
+Powering up a fainted Pokémon will revive it, but with minimal \HP\@:
+\[ \HP = \min{1, \MHP_\mathrm{New} - \MHP_\mathrm{Old} } \]
 Advancing a normal Pokémon from level 1 to level 50 is not a cheap endeavor (\autoref{table:sumcosts}),
   though Shadow Pokémon of course have a minimum level of eight, purified Pokémon are always
   at least level 25, and most captures will be well above level 1.
@@ -166,11 +166,11 @@ This discount stacks with the 10\% purification discount, so costs for
 We'll define some statistics for each Pokémon.
 These values are used as inputs to battle mechanics.
 First, sum the Species's ATK, DEF, and STA with the Pokémon's
- IVs to generate $Mod_A$, $Mod_D$, and $Mod_S$:
+IVs to generate \Mod{A}, \Mod{D}, and \Mod{S}:
 \begin{align*}
-   Mod_A &= ATK + IV_A \\
-   Mod_D &= DEF + IV_D \\
-   Mod_S &= STA + IV_S
+ \Mod{A} &= \mathit{ATK} + \mathit{IV_\mathrm{A}} \\
+ \Mod{D} &= \mathit{DEF} + \mathit{IV_\mathrm{D}} \\
+ \Mod{S} &= \mathit{STA} + \mathit{IV_\mathrm{S}}
 \end{align*}
 These are typically scaled by the Pokémon's Combat Power Multiplier.
 \section{Combat Power Multiplier\label{sec:cpm}}
@@ -178,17 +178,17 @@ Recall that each Pokémon has its own Level, ranging from 1.0
  to 50.0, defined on half integers\footnote{I would rather they
  simply be integer Levels 1--99, but this is settled terminology.}.
 This Level is used as an index into a table of positive rational constants.
-The value accessed is that Pokémon's Combat Power Multiplier (CPM).
-CPM maxes out at Level 50 with a value of 0.8403, and takes its 
+The value accessed is that Pokémon's Combat Power Multiplier (\CPM).
+\CPM{} maxes out at Level 50 with a value of 0.8403, and takes its
   0.094 minimum at Level 1.
-At Level 10, CPM is 0.4225, almost half of its maximum value.
-At Level 34, CPM is 0.7557, about 90\% of its maximum value.
+At Level 10, \CPM{} is 0.4225, almost half of its maximum value.
+At Level 34, \CPM{} is 0.7557, about 90\% of its maximum value.
 The extremal ratios are 0.1119 (L1 / L50) and 8.9394 (L50 / L1).
 
 \begin{table}
 \centering
 \begin{tabular}{l l|l l|l l}
-Level & CPM & Level & CPM & Level & CPM \\
+Level & \CPM & Level & \CPM & Level & \CPM \\
 \Midrule
 1.0 & 0.0940 & 17.5 & 0.5588 & 34.0 & 0.7557 \\ 
 1.5 & 0.1351 & 18.0 & 0.5668 & 34.5 & 0.7586 \\

--- a/006-pgo/pokémon.tex
+++ b/006-pgo/pokémon.tex
@@ -228,7 +228,7 @@ Level & CPM & Level & CPM & Level & CPM \\
 \end{table}
 
 \section{Effective stats\label{sec:effectivestats}}
-Multiplying $Mod_S$ by CPM yields $Eff_S$, which determines a Pokémon's Maximum Hit Points (MHP).
+Multiplying $\mathit{Mod_S}$ by CPM yields $\mathit{Eff_S}$, which determines a Pokémon's Maximum Hit Points (MHP).
 When a Pokémon's Hit Points are reduced to 0, it is knocked out, and cannot be
  used (nor made a Buddy) until revived.
 Hit Points are persistent across Raids, Max Battles, and Team Rocket encounters,

--- a/006-pgo/simul.tex
+++ b/006-pgo/simul.tex
@@ -61,7 +61,7 @@ Furthermore, questions like those earlier in this chapter become harder to answe
 A naive solution begins at the first turn, generates the set of possible
   choices for both Trainers, and recurses across the Cartesian product
   of these sets: depth-first generation of the full game tree.
-For each state, we must preserve the HP and energy of six Pokémon,
+For each state, we must preserve the \HP{} and energy of six Pokémon,
   the attack and defense buff level for two Pokémon,
   the number of turns remaining in two ongoing fast attacks,
   the number of shields remaining for each Trainer,
@@ -133,7 +133,7 @@ If there is one Pokémon remaining, bring it in and continue simulating.
 If two more Pokémon remain, we must simulate both replacements.
 \inputminted{cpp}{s/ko.h}
 The presented code simulates all possible meaningful exchanges of two fully specified Pokémon, starting
-  with full HP, two shields, and no energy.
+  with full \HP{}, two shields, and no energy.
 
 \lstinputlisting[basicstyle=\scriptsize]{out/simulout.lst}
 
@@ -146,7 +146,7 @@ Even better would be a closed form analytic treatment of the endgame,
   which seems like it ought be possible.
 Let's restrict ourselves to the case of one Pokémon remaining per Trainer.
 We dispense with charged attacks entirely (at least initially) by considering
-  only those states where the possible turns remaining times EPT plus
+  only those states where the possible turns remaining times \EPT{} plus
   energy is less than the energy required for a charged attack.
 This restriction means we can ignore shields, as they're only relevant
   when charged attacks are used.
@@ -154,13 +154,13 @@ We call these subgraphs ``death marches''.
 
 How do we put an upper bound on turns?
 
-\[ T_{max} = \min \left\lceil\frac{HP_1}{D_2}\right\rceil T_2,\left\lceil\frac{HP_2}{D_1}\right\rceil T_1 \]
+\[ T_\mathrm{max} = \min \left\lceil\frac{\HP_1}{D_2}\right\rceil T_2,\left\lceil\frac{\HP_2}{D_1}\right\rceil T_1 \]
 
 $D$ is the damage inflicted per fast attack, and $T$ is the number of turns per fast attack.
 This equation is well-defined for all attacks, since damage (unlike power,
   which can be zero) is always at least 1.
-So, knowing $T_{max}$, we can determine those cases where no charged attack
-  can be used: whenever $T_{max} * EPT + E_{current} < E_{charged}$ for both Pokémon.
+So, knowing $T_\mathrm{max}$, we can determine those cases where no charged attack
+  can be used: whenever $T_\mathrm{max} * \mathit{\EPT{}} + E_\mathrm{current} < E_\mathrm{charged}$ for both Pokémon.
 There is only one possible path through such a subtree, with one answer:
   whichever Pokémon has a lower $T$ wins.
 

--- a/006-pgo/spawn.tex
+++ b/006-pgo/spawn.tex
@@ -223,7 +223,7 @@ Razz  & 150\% catch percentage\\
 Nanab & Immobilizes Pokémon\\
 Pinap & Boosts Candy rewards: 3→7, 5→11, 10→23\\
 Silver pinap & 180\% catch percentage\newline Boosts Candy rewards: 3→7, 5→11, 10→23\\
-Golden razz & 250\% catch percentage\newline Restore full HP to Gym defender\\
+Golden razz & 250\% catch percentage\newline Restore full \HP{} to Gym defender\\
 \end{tabular}
   \caption{Berries and their uses\label{table:berries}}
 \end{table}

--- a/006-pgo/spawn.tex
+++ b/006-pgo/spawn.tex
@@ -5,13 +5,13 @@ Trainers primarily interface with the Map screen, onto which is projected
 Pokémon spawning on this map will be a Trainer's major source of raw materials.
 In addition to the Map, encounters follow victories against Team GO Rocket,
   wins in raids and Max Battles, and completion of certain research.
-Encounters feature a summary display including the Pokémon's CP (\autoref{sec:cp}),
+Encounters feature a summary display including the Pokémon's \CP{} (\autoref{sec:cp}),
   and icons indicating any weather leading to boosting (\autoref{sec:weather}),
   any type of lure that led to the spawn,
   Shiny status,
   and that the species has been previously captured\footnote{These traits are stored, and can be seen when browsing inventory.}.
-The CP will be replaced with ``???'' if the species has never been seen, or if
-  the CP exceeds that of any owned Pokémon.
+The \CP{} will be replaced with ``???'' if the species has never been seen, or if
+  the \CP{} exceeds that of any owned Pokémon.
 
 \section{Wild spawns\label{sec:spawns}}
 Decorations around a Pokémon indicate how it spawned (\autoref{table:spawnreasons}).

--- a/006-pgo/spawn.tex
+++ b/006-pgo/spawn.tex
@@ -105,12 +105,12 @@ Pokémon that flee do not reappear on the map\footnote{The Trainer does receive 
 While holding a ball, a target ring will encircle the Pokémon, looping from a maximum to a minimum size.
 Its color (red, orange, or green) is an indicator of the capture probability $P_C$:
 \begin{align*}
-  P_C &= 1-\left(1 - \frac{C}{2\cdot{}CPM}\right)^{M_C}\\
-  M_C &= M_{Ball} \cdot M_{Berry} \cdot M_{Throw} \cdot M_{Medal} \cdot M_{Adv} \cdot M_{Enc}
+  P_C &= 1-\left(1 - \frac{C}{2\cdot{}\mathit{CPM}}\right)^{M_C}\\
+  M_C &= M_\mathrm{Ball} \cdot M_\mathrm{Berry} \cdot M_\mathrm{Throw} \cdot M_\mathrm{Medal} \cdot M_\mathrm{Adv} \cdot M_\mathrm{Enc}
 \end{align*}
 \begin{itemize}
-  \item $CPM$ is the Combat Power Multiplier (\autoref{sec:cpm}).
-  \item $M_{Ball}$ is the multiplier due the ball:
+  \item $\mathit{CPM}$ is the Combat Power Multiplier (\autoref{sec:cpm}).
+  \item $M_\mathrm{Ball}$ is the multiplier due the ball:
 \begin{table}[h!]
 \centering
 \begin{tabular}{lr}
@@ -123,26 +123,26 @@ Master & ∞\\
 \end{tabular}
   \caption{Balls and their capture multipliers\label{table:balls}}
 \end{table}
-\item $M_{Berry}$ is the multiplier due a berry (\autoref{table:berries}).
-\item $M_{Throw}$ is the multiplier due throw accuracy. Throw accuracy is summarized
+\item $M_\mathrm{Berry}$ is the multiplier due a berry (\autoref{table:berries}).
+\item $M_\mathrm{Throw}$ is the multiplier due throw accuracy. Throw accuracy is summarized
    with ``Excellent!'', ``Great!'', ``Nice!'', or silence.
-    This summary is a low-resolution signal of $M_{Throw}$, with a range over [1.0, 2.0].
+    This summary is a low-resolution signal of $M_\mathrm{Throw}$, with a range over [1.0, 2.0].
 \begin{table}[h!]
 \centering
 \begin{tabular}{lr}
-Summary & $M_{Throw}$ range\\
+Summary & $M_\mathrm{Throw}$ range\\
 \Midrule
 ``Excellent!'' & [1.7, 2.0]\\
 ``Great!'' & [1.3, 1.7)\\
 ``Nice!'' & [1.0, 1.3)\\
 No summary & 1\\
 \end{tabular}
-  \caption{The throw summary is an indication of $M_{Throw}$\label{table:throw}}
+  \caption{The throw summary is an indication of $M_\mathrm{Throw}$\label{table:throw}}
 \end{table}
-$M_{Throw}$ is multiplied by 1.7 for a curveball.
-\item $M_{Medal}$ is the multiplier due medals (\autoref{sec:medals}).
-\item $M_{Adv}$ is 1.5 for Ice Burn, 1.25 for Freeze Shock, and 1 otherwise.
-\item $M_{Enc}$ is 2 for research encounters, and 1 otherwise.
+$M_\mathrm{Throw}$ is multiplied by 1.7 for a curveball.
+\item $M_\mathrm{Medal}$ is the multiplier due medals (\autoref{sec:medals}).
+\item $M_\mathrm{Adv}$ is 1.5 for Ice Burn, 1.25 for Freeze Shock, and 1 otherwise.
+\item $M_\mathrm{Enc}$ is 2 for research encounters, and 1 otherwise.
 \end{itemize}
 If you throw your ball too directly at Tyrunt, it'll eat it.
 If a response is not received from the server in a timely fashion, the Pokémon will escape.

--- a/006-pgo/spawn.tex
+++ b/006-pgo/spawn.tex
@@ -105,8 +105,8 @@ Pokémon that flee do not reappear on the map\footnote{The Trainer does receive 
 While holding a ball, a target ring will encircle the Pokémon, looping from a maximum to a minimum size.
 Its color (red, orange, or green) is an indicator of the capture probability $P_C$:
 \begin{align*}
-  P_C &= 1-\left(1 - \frac{C}{2\cdot{}\CPM}\right)^{M_C}\\
-  M_C &= M_\mathrm{Ball} \cdot M_\mathrm{Berry} \cdot M_\mathrm{Throw} \cdot M_\mathrm{Medal} \cdot M_\mathrm{Adv} \cdot M_\mathrm{Enc}
+  P_\mathrm{C} &= 1-\left(1 - \frac{C}{2\cdot{}\CPM}\right)^{M_\mathrm{C}}\\
+  M_\mathrm{C} &= M_\mathrm{Ball} \cdot M_\mathrm{Berry} \cdot M_\mathrm{Throw} \cdot M_\mathrm{Medal} \cdot M_\mathrm{Adv} \cdot M_\mathrm{Enc}
 \end{align*}
 \begin{itemize}
   \item \CPM{} is the Combat Power Multiplier (\autoref{sec:cpm}).

--- a/006-pgo/spawn.tex
+++ b/006-pgo/spawn.tex
@@ -105,11 +105,11 @@ Pokémon that flee do not reappear on the map\footnote{The Trainer does receive 
 While holding a ball, a target ring will encircle the Pokémon, looping from a maximum to a minimum size.
 Its color (red, orange, or green) is an indicator of the capture probability $P_C$:
 \begin{align*}
-  P_C &= 1-\left(1 - \frac{C}{2\cdot{}\mathit{CPM}}\right)^{M_C}\\
+  P_C &= 1-\left(1 - \frac{C}{2\cdot{}\CPM}\right)^{M_C}\\
   M_C &= M_\mathrm{Ball} \cdot M_\mathrm{Berry} \cdot M_\mathrm{Throw} \cdot M_\mathrm{Medal} \cdot M_\mathrm{Adv} \cdot M_\mathrm{Enc}
 \end{align*}
 \begin{itemize}
-  \item $\mathit{CPM}$ is the Combat Power Multiplier (\autoref{sec:cpm}).
+  \item \CPM{} is the Combat Power Multiplier (\autoref{sec:cpm}).
   \item $M_\mathrm{Ball}$ is the multiplier due the ball:
 \begin{table}[h!]
 \centering
@@ -347,7 +347,7 @@ Put another way, if you have a 5\% chance of an outcome, and do tests in sets of
 Put yet another way, over the long run, you can expect a little over two Shiny
  Pokémon for every thousand wild spawns.\\
 
-The probability of an outcome with probability $P$ never being seen in $N$ independent
+The probability of an outcome with probability $P$\, never being seen in $N$ independent
   events is ${(1 - P)}^N$. For a 5\% likelihood, $1 - P = 0.95$. For thirteen events,
 
   \[ 0.95^{13} ≈ 0.513 \]

--- a/006-pgo/species.tex
+++ b/006-pgo/species.tex
@@ -101,8 +101,8 @@ G-Max attacks have power of 350, 400, and 450, 100 more than Dynamax attacks of 
 Max Guard bestows a protective shield (the Guard) on all active Pokémon
   with fewer than three Guards.
 This Guard will absorb 20, 40, or 60 points of damage, depending on Max Guard's level.
-Max Spirit restores HP to active Pokémon.
-The amount restored is a percentage of each affected Pokémon's MHP\@;
+Max Spirit restores \HP{} to active Pokémon.
+The amount restored is a percentage of each affected Pokémon's \MHP\@;
   the percentage (8\%, 12\%, or 16\%) is based on Max Spirit's level.
 \clearpage
 \input{out/gigantas}
@@ -198,7 +198,7 @@ Some evolutions can be performed at no Candy cost if the Pokémon was received b
  (\autoref{table:tradeevolution}).
 Evolution usually improves base stats (though there are many exceptions to this rule),
   and typically makes available new, more powerful attacks.
-Evolution revives a Pokémon if it is fainted, and always fully restores HP\@.
+Evolution revives a Pokémon if it is fainted, and always fully restores \HP\@.
 \begin{table}
 \footnotesize
 \centering
@@ -550,7 +550,7 @@ At any time, there is a set of Pokémon which might actually be Ditto,
 When captured, the Pokémon will be revealed as Ditto, and Ditto Candy will take
   the place of expected Candy.
 Ditto status is shared across Trainers, i.e. it is a property of the spawn, not the encounter.
-In battle, Ditto adopts the moves, typing, ATK, and DEF of its opponent, but not its MHP\@.
+In battle, Ditto adopts the moves, typing, ATK, and DEF of its opponent, but not its \MHP\@.
 The result is almost universally garbage, and Ditto can't be used in 3x3 anyway\footnote{It is one of two species banned from PvP, the other being Shedinja.}.
 The spiteful fox Zorua copies your Buddy Pokémon when it spawns; if you have no Buddy
   Pokémon, it spawns as itself.

--- a/006-pgo/tactics.tex
+++ b/006-pgo/tactics.tex
@@ -261,7 +261,7 @@ No efficiency is lost relative to the three case, though neither three nor six a
 The true maximum efficiency cannot be reached.
 
 \begin{tabular}{lrrrr}
-  Turn A throws & $R$ & A fast attacks & B fast attacks & Ratio \\
+  Turn $A$ throws & $R$ & $A$ fast attacks & $B$ fast attacks & Ratio \\
 \Midrule
   0 & 5 & 0 & 1 & 0 \\
   3 & 2 & 1 & 1 & 1\\
@@ -281,7 +281,7 @@ The true maximum efficiency cannot be reached.
 \end{tabular}
 
 \begin{tabular}{lrrrr}
-  Turn B throws & $R$ & A fast attacks & B fast attacks & Ratio\\
+  Turn $B$ throws & $R$ & $A$ fast attacks & $B$ fast attacks & Ratio\\
 \Midrule
   0 & 3 & 1 & 0 & 0 \\
   5 & 1 & 1 & 2 & 0.5\\

--- a/006-pgo/tactics.tex
+++ b/006-pgo/tactics.tex
@@ -6,8 +6,8 @@ A Trainer's Pokémon enable tactics, and tactics guide Pokémon selection.
 
 One of the greatest advantages one can gain is knowledge.
 Know Pokémon well, especially those on your team and those you regularly see.
-Know what moves they can learn, and how hard they throw them (Power and $Eff_A$).
-Knowing their bulk ($Eff_D$ times MHP) can help decide which charged attack to use.
+Know what moves they can learn, and how hard they throw them (Power and $\mathit{Eff_A}$).
+Knowing their bulk ($\mathit{Eff_D}$ times MHP) can help decide which charged attack to use.
 Know type relations cold, and be able to calculate type effectiveness on the fly.
 The flipside of this is exploitation of ignorance.
 Opposing Trainers are less likely to know Pokémon outside the ``meta'',

--- a/006-pgo/tactics.tex
+++ b/006-pgo/tactics.tex
@@ -6,8 +6,8 @@ A Trainer's Pokémon enable tactics, and tactics guide Pokémon selection.
 
 One of the greatest advantages one can gain is knowledge.
 Know Pokémon well, especially those on your team and those you regularly see.
-Know what moves they can learn, and how hard they throw them (Power and $\mathit{Eff_A}$).
-Knowing their bulk ($\mathit{Eff_D}$ times MHP) can help decide which charged attack to use.
+Know what moves they can learn, and how hard they throw them (Power and \Eff{A}).
+Knowing their bulk (\Eff{D} times \MHP) can help decide which charged attack to use.
 Know type relations cold, and be able to calculate type effectiveness on the fly.
 The flipside of this is exploitation of ignorance.
 Opposing Trainers are less likely to know Pokémon outside the ``meta'',
@@ -61,7 +61,7 @@ If your Pokémon has almost enough energy to throw a charged attack, but is clos
 When they come back, the situation might have changed so that they can get the attack off,
  rather than wasting the builtup energy.
 A downside is that an incoming charged attack will probably inflict more total
- damage on a healthy Pokémon than one with little HP to lose.
+ damage on a healthy Pokémon than one with little \HP{} to lose.
 
 \subsection{Charged move subterfuge}
 It's best to keep an opponent guessing as to your charged moves.
@@ -72,7 +72,7 @@ By holding onto a charged attack longer than necessary, a Pokémon can build
   that requires more energy (and thus presumably packs more power).
 An opponent that would have absorbed the relatively weak charged attack
   might be induced to blow a shield instead.
-This can be particularly effective when the opponent can be drawn down to low HP
+This can be particularly effective when the opponent can be drawn down to low \HP{}
   and has one shield left.
 The charged attack comes, and is mistaken for a very powerful attack.
 A shield is deployed, with the reasoning that the attacked Pokémon can
@@ -104,7 +104,7 @@ Furthermore, the original threat is still lurking, our original Pokémon is stil
 There's no faster way to lose a match.
 How, then, to deal with a highly disadvantageous initial matchup?
 
-One can always accept the loss of their lead Pokémon, trying to take some shields and HP with them.
+One can always accept the loss of their lead Pokémon, trying to take some shields and \HP{} with them.
 This is not unreasonable if the Trainer has a strong counter at position two or three
   that can come out and mow down the initial Pokémon.
 The opponent will of course be able to bring in their own counter when their lead goes down.
@@ -164,28 +164,28 @@ Recall from \autoref{chap:battle} that charged attacks:
 A result of these mechanics is that on the turn following a charged attack,
  both Pokémon are ready to throw a new attack.
 
-Pokémon A concludes their $T_A$-turn fast attack, and has sufficient energy to throw a charged attack.
-If Pokémon B has a one-turn fast attack, everything is very simple;
+Pokémon $A$ concludes their $T_A$-turn fast attack, and has sufficient energy to throw a charged attack.
+If Pokémon $B$ has a one-turn fast attack, everything is very simple;
  A can throw charged attacks whenever they'd like.
-If Pokémon B is in the middle of a $T_B$-turn fast attack, with $R$ turns remaining,
+If Pokémon $B$ is in the middle of a $T_B$-turn fast attack, with $R$ turns remaining,
  and $T_A < R$, throwing the charged attack constitutes a blunder\footnote{Unless it wins the match.}.
-It brings Pokémon B's fast attack to an early conclusion, leaving them ready to start a new attack.
-If instead Pokémon A runs a fast attack, that attack completes before Pokémon B's, inflicting damage and generating energy.
+It brings Pokémon $B$'s fast attack to an early conclusion, leaving them ready to start a new attack.
+If instead Pokémon $A$ runs a fast attack, that attack completes before Pokémon $B$'s, inflicting damage and generating energy.
 The charged attack can then be thrown.
 In the extreme case of facing an attack of five turns while using one of a single turn,
   you can get four attacks in before optimally launching the charged attack.
 
-Let's assume Pokémon A employs Poison Jab, a two-turn fast attack.
-Pokémon B throws five-turn Incinerate at $T_n$.
-If Pokémon A throws its charged attack, at $T_{n+1}$ it will have inflicted
+Let's assume Pokémon $A$ employs Poison Jab, a two-turn fast attack.
+Pokémon $B$ throws five-turn Incinerate at $T_n$.
+If Pokémon $A$ throws its charged attack, at $T_{n+1}$ it will have inflicted
   one charged attack, and suffered one fast attack.
-Instead, Pokémon A throws Poison Jab, which concludes on $T_{n+1}$, dealing damage and charging energy.
-On $T_{n+2}$, Pokémon A launches Poison Jab a second time, concluding on $T_{n+3}$.
-Finally, at $T_{n+4}$, Pokémon A throws its charged attack.
+Instead, Pokémon $A$ throws Poison Jab, which concludes on $T_{n+1}$, dealing damage and charging energy.
+On $T_{n+2}$, Pokémon $A$ launches Poison Jab a second time, concluding on $T_{n+3}$.
+Finally, at $T_{n+4}$, Pokémon $A$ throws its charged attack.
 The result when $T_{n+5}$ rolls around is that both stand ready to throw new attacks,
-  but Pokémon A has the benefit of two extra fast attacks.
+  but Pokémon $A$ has the benefit of two extra fast attacks.
 Compared to throwing the charged attack prior to $T_{n+4}$,
-  Pokémon A has inflicted more damage and built up more energy.
+  Pokémon $A$ has inflicted more damage and built up more energy.
 A result: if your fast attack is fewer turns than your opponent's,
  and you're both set to choose attacks,
  \textit{don't throw a charged attack if you expect them to throw a fast attack}.
@@ -197,21 +197,21 @@ Optimal timing requires throwing charged moves only when $R=1$, and continuously
 This is impossible to do when $T_A$ is a multiple of $T_B$\footnote{In my opinion, long fast moves are an advantage against weak competition, and a disadvantage
  against strong competition. Weak competition is more likely to throw early, giving up fast attacks. Strong competition
  won't do so, and you never get those attacks.}.
-The interesting case is when $1 < R \le T_A$ (if $1=R$, the charged attack is optimally timed; if $R > T_A$, throw a fast attack).
+ The interesting case is when $1 < R \le T_A$ (if $1=R$, the charged attack is optimally timed; if $R > T_A$, throw a fast attack).
 Replace Poison Jab with Astonish (three turns).
 It throws Astonish at $T_n$, concluding at $T_{n+2}$.
 Throwing Astonish a second time won't see it conclude until $T_{n+5}$.
-Assume Pokémon B throws a second Incinerate at $T_{n+5}$.
+Assume Pokémon $B$ throws a second Incinerate at $T_{n+5}$.
 The time between charged attacks can be thought of as a ``period''
  in which each Pokémon lands some number of fast attacks.
 A Trainer wants to maximize the ratio of their fast attacks to their opponent's.
-If Pokémon A throws its charged attack at $T_{n+6}$, at $T_{n+7}$ Pokémon B has landed two Incinerates
+If Pokémon $A$ throws its charged attack at $T_{n+6}$, at $T_{n+7}$ Pokémon $B$ has landed two Incinerates
   against two Astonishes and a charged attack.
 A charged attack at $T_{n+3}$ would lead to one Incinerate against one Astonish
   and a charged attack.
-Pokémon A catches up at $T_{n+9}$, when it has thrown three attacks, and Pokémon B is
+Pokémon $A$ catches up at $T_{n+9}$, when it has thrown three attacks, and Pokémon $B$ is
   completing its second.
-This 3:2 ratio seems as good as it gets for Pokémon A.
+This 3:2 ratio seems as good as it gets for Pokémon $A$.
 At $T_{n+12}$, we're down to 4:3, and $T_{n+15}$ is 5:4.
 
 \begin{tipbox}[title=Warning! Achtung! \begin{chinese}危险！\end{chinese} ¡Peligro! \begin{japanese}危険!\end{japanese} \textit{Tulaga faigata!}]
@@ -226,11 +226,11 @@ Nonetheless, I'm pretty sure they're all wrong, and I'm right.
  and Wallower's YouTube video ``\href{https://www.youtube.com/watch?v=pAtCo8xg700}{GBL Advanced Mechanics 1: Charged Move Timing}'' (2021).}.
 But this rule is incomplete.
 
-Pokémon B's fast moves complete on turns $T_{n+5a-1}$ for positive integers $a$.
-Pokémon A can throw charged moves on turns $T_{n+3b}$ for non-negative integers $b$.
+Pokémon $B$'s fast moves complete on turns $T_{n+5a-1}$ for positive integers $a$.
+Pokémon $A$ can throw charged moves on turns $T_{n+3b}$ for non-negative integers $b$.
 The rule considers $T_{n+9+15c}$ for non-negative integers $c$ optimal times to throw
  ($T_{n+9}, T_{n+24}, \dots$), and these are indeed \textit{locally} optimal.
-At $T_{n+18}$, the ratio is 6:4, the same as 3:2, despite \textit{not} being the last turn of Pokémon B's attack.
+At $T_{n+18}$, the ratio is 6:4, the same as 3:2, despite \textit{not} being the last turn of Pokémon $B$'s attack.
 And at $T_{n+24}$, the ratio is 8:5, \textit{better} than $T_{n+9}$!
 The maxima converge to 5:3.
 
@@ -244,7 +244,7 @@ The maxima converge to 5:3.
 \caption{Ratios of 3- and 5-turn fast moves (200 turns)\label{figure:35ratios}}
 \end{figure}
 
-What about Pokémon B\@?
+What about Pokémon $B$\@?
 Ideally they get their charged move out at $T_{n+5}$, for a 1:1 ratio.
 At $T_{n+10}$ the ratio is 2:4, but at $T_{n+15}$ it is 3:6, despite landing on the first turn of the sixth fast attack.
 At $T_{n+20}$ the ratio is 4:7, but it falls back to 5:9 at $T_{n+25}$.
@@ -254,7 +254,7 @@ Simply postponing a charged move can be just as or more effective than timing wi
   respect to the opponent's fast attack.
 Why is this important?
 It can be useful to delay a charged attack for any number of reasons.
-If Pokémon A was willing to accept a 1.5 ratio, throwing after three Astonish
+If Pokémon $A$ was willing to accept a 1.5 ratio, throwing after three Astonish
   attacks suffices, but six works as well, despite not being the last turn of an Incinerate.
 No efficiency is lost relative to the three case, though neither three nor six are as
   efficient as 24.

--- a/006-pgo/trainer.tex
+++ b/006-pgo/trainer.tex
@@ -60,8 +60,8 @@ Level & MXP & ΔMXP & Special requirements \\
                        50 Excellent throws,
                        30 Eggs hatched\\
 47 & 100 & 18 & 30 raid wins with heterogenous teams,\newline
-                        3🟉+ Raid win with CP1500-bounded team,\newline
-                        3 power ups to Max CP, 20 platinum medals\\
+                        3🟉+ Raid win with \CP1500-bounded team,\newline
+                        3 power ups to Max \CP, 20 platinum medals\\
 48 & 121 & 21 & 10 Souvenirs from buddy,
                         300 hearts with buddy,
                         200 km walked with buddy,
@@ -71,7 +71,7 @@ Level & MXP & ΔMXP & Special requirements \\
                         500 gifts sent,
                         35 platinum medals\\
 50 & 176 & 30 & 5 consecutive Legendary/Mythical catches,
-                        3 GO Rocket Leader wins with CP2500-bounded teams,
+                        3 GO Rocket Leader wins with \CP2500-bounded teams,
                         Rank 10 in GO Battle League,
                         999 Excellent throws\\
 \end{tabular}

--- a/006-pgo/types.tex
+++ b/006-pgo/types.tex
@@ -193,8 +193,8 @@ Thankfully, these needn't be memorized, as they can all be calculated
  using the base relations matrix.
 \input{out/dualtypes.tex}
 Given $E_{n}, −3 \le n \le 2$ where $E_n$ is the number of types with
-  a net relation of $n$ against a typing, we define DRA\@:
-\[  DRA = \sum_{n=−3}^{2} \frac{E_{n}1.6^n}{18} \]
+  a net relation of $n$ against a typing, we define \DRA\@:
+\[  \DRA = \sum_{n=−3}^{2} \frac{E_{n}1.6^n}{18} \]
 Completely unexpectedly, the defensive typings with highest DRA include Steel,
   with the top fiften spots all making use of it.
 Don't be fooled by a metric like DRA, though; you will not be seeing

--- a/006-pgo/unbounded.tex
+++ b/006-pgo/unbounded.tex
@@ -44,8 +44,8 @@ The quadratic term for CPM makes sense from the perspective of the damage
 But since CPM is also used to calculate MHP from $Mod_S$, an argument
  can be made that it ought be raised to the third power.
 Since $CPM < 1$ for all Levels, $CPM^3 < CPM^2$, and thus it seems \textit{overvalued} by CP\@.
-Finally, recall that $MHP = \lfloor Eff_S \rfloor$.
-Since the observable $MHP$ increases only stepwise with respect to $Eff_S$,
+Finally, recall that $MHP = \lfloor \mathit{Eff_S} \rfloor$.
+Since the observable $MHP$ increases only stepwise with respect to $\mathit{Eff_S}$,
   there is a stepwise overvaluation of $Mod_S$.
 This doesn't correct the undervaluation due the square root, but it does
   have effects: a 0/14/13 level 30.5 Clodsire has the same MHP
@@ -60,7 +60,7 @@ Since Raids allow substitution of defeated Pokémon, but are subject to a timer,
   the ability to defend and absorb damage is less important than being able to
   quickly inflict damage.
 Furthermore, when two Pokémon launch charged attacks on the same turn in a Trainer
-  Battle, $Eff_A$ determines which goes first (\autoref{sec:3x3}).
+  Battle, $\mathit{Eff_A}$ determines which goes first (\autoref{sec:3x3}).
 Perhaps this explains the emphasis on attack, but some of the most important
   factors in the damage equation are left out of CP entirely!
 The power and timing of the Pokémon's attacks are not present, despite
@@ -156,7 +156,7 @@ Attacks of longer duration allow the opponent to blunder with regard to the
 Short attacks credit damage more quickly than long ones.
 There's no general rule: fast attack selection comes down to attack type
   (both for effectiveness and STAB), the Pokémon's charged attacks,
-  and even the $\frac{P \cdot Eff_A}{Eff_D}$ of expected opponents.
+  and even the $\frac{P \cdot \mathit{Eff_A}}{\mathit{Eff_D}}$ of expected opponents.
 Some Pokémon can learn two fast attacks of the same type and duration,
   where one is strictly inferior to the other in terms of power and
   energy.

--- a/006-pgo/unbounded.tex
+++ b/006-pgo/unbounded.tex
@@ -20,36 +20,36 @@ Even were this not the case, the situation into which a Pokémon is deployed
  can change drastically from match to match.
 Accurate prediction comes not via stats, but simulation (\autoref{chap:simul}).
 
-Yet the game provides a per-Pokémon ordered measure of strength in battle: Combat Power (CP).
+Yet the game provides a per-Pokémon ordered measure of strength in battle: Combat Power (\CP).
 Obviously no single statistic can account for all possible opponents, but
- we will see that CP is a very questionable assessment for a PvP
+ we will see that \CP{} is a very questionable assessment for a PvP
  context (and not great for PvE, either).
 
 \section{Combat Power\label{sec:cp}}
-A Pokémon's CP is defined as:
-\[ CP = \max{10, \frac{Mod_A \cdot \sqrt{Mod_D} \cdot \sqrt{Mod_S} \cdot CPM^2}{10}} \]
-CP growth is quadratic with respect to $CPM$, linear with $Mod_A$, and
-  sublinear with $Mod_D$ and $Mod_S$.
-Remember from our damage equation that $Mod_A$ is divided by $Mod_D$
+A Pokémon's \CP{} is defined as:
+\[ \CP = \max{10, \frac{\Mod{A} \cdot \sqrt{\Mod{D}} \cdot \sqrt{\Mod{S}} \cdot \CPM^2}{10}} \]
+\CP{} growth is quadratic with respect to \CPM, linear with \Mod{A}, and
+  sublinear with \Mod{D} and \Mod{S}.
+Remember from our damage equation that \Mod{A} is divided by \Mod{D}
  to generate one of the factors.
-This suggests that $Mod_D$ is undervalued by the CP equation, from which
- we might expect $Mod_A$ to be divided by $\sqrt{Mod_D}$.
-MHP isn't used in the damage equation, but knocking out a Pokémon
+This suggests that \Mod{D} is undervalued by the \CP{} equation, from which
+ we might expect \Mod{A} to be divided by \Mod{D}.
+\MHP{} isn't used in the damage equation, but knocking out a Pokémon
  requires inflicting some average damage $D$ $n$ times,
- where $n = \lceil\frac{MHP}{D}\rceil$.
-It is thus similarly undervalued by CP\@.
-The quadratic term for CPM makes sense from the perspective of the damage
- equation, since CPM is used as a factor when calculating damage in the
+ where $n = \lceil\frac{\MHP}{D}\rceil$.
+It is thus similarly undervalued by \CP\@.
+The quadratic term for \CPM{} makes sense from the perspective of the damage
+ equation, since \CPM{} is used as a factor when calculating damage in the
  case of both the attacker and defender.
-But since CPM is also used to calculate MHP from $Mod_S$, an argument
+But since \CPM{} is also used to calculate \MHP{} from \Mod{S}, an argument
  can be made that it ought be raised to the third power.
-Since $CPM < 1$ for all Levels, $CPM^3 < CPM^2$, and thus it seems \textit{overvalued} by CP\@.
-Finally, recall that $MHP = \lfloor \mathit{Eff_S} \rfloor$.
-Since the observable $MHP$ increases only stepwise with respect to $\mathit{Eff_S}$,
-  there is a stepwise overvaluation of $Mod_S$.
+Since $\CPM < 1$ for all Levels, $\CPM^3 < \CPM^2$, and thus it seems \textit{overvalued} by \CP\@.
+Finally, recall that $\MHP = \lfloor \Eff{S} \rfloor$.
+Since the observable \MHP{} increases only stepwise with respect to \Eff{S},
+  there is a stepwise overvaluation of \Mod{S}.
 This doesn't correct the undervaluation due the square root, but it does
-  have effects: a 0/14/13 level 30.5 Clodsire has the same MHP
-  as a 0/14/14 at the same level (213), but a CP of 1499 as
+  have effects: a 0/14/13 level 30.5 Clodsire has the same \MHP{}
+  as a 0/14/14 at the same level (213), but a \CP{} of 1499 as
   opposed to the latter's 1502.
 Despite being exactly the same on the field, one is allowed in Great League,
   and the other is prohibited.
@@ -60,14 +60,14 @@ Since Raids allow substitution of defeated Pokémon, but are subject to a timer,
   the ability to defend and absorb damage is less important than being able to
   quickly inflict damage.
 Furthermore, when two Pokémon launch charged attacks on the same turn in a Trainer
-  Battle, $\mathit{Eff_A}$ determines which goes first (\autoref{sec:3x3}).
+  Battle, \Eff{A} determines which goes first (\autoref{sec:3x3}).
 Perhaps this explains the emphasis on attack, but some of the most important
-  factors in the damage equation are left out of CP entirely!
+  factors in the damage equation are left out of \CP{} entirely!
 The power and timing of the Pokémon's attacks are not present, despite
   dominating the inflicted damage and overall flow of the battle.
 Type effectiveness and STAB have been likewise ignored, as have the
   properties of Shadow Pokémon.
-It ought be clear that we must look beyond CP in our selection of Pokémon.
+It ought be clear that we must look beyond \CP{} in our selection of Pokémon.
 
 Remember that a type advantage is more impactful than a type
   disadvantage (60\% vs -37.5\%):
@@ -107,25 +107,25 @@ As with most such questions, we could answer ``the details are opponent-dependen
 Somewhat vaguely, we might reply, ``they're worth a couple levels''.
 More concretely, we can say ``they're more important with low base stats, less important
   with higher base stats''.
-Quantitatively, we can say ``An $IV_A$ of 15 is worth more than STAB to an
+Quantitatively, we can say ``An \IV{A} of 15 is worth more than STAB to an
   attacker with ATK less than 75. It is worth exactly as much (20\%) as STAB
   to an attacker with ATK of exactly 75. It is worth less than STAB
   to an attacker with ATK greater than 75.''
-Similarly, an $IV_A$ of 15 is equal to type effectiveness of 1 when ATK is 25.
-For a more plausible ATK of 150, a maximum $IV_A$ is worth a 10\% bonus to attack.
+Similarly, an \IV{A} of 15 is equal to type effectiveness of 1 when ATK is 25.
+For a more plausible ATK of 150, a maximum \IV{A} is worth a 10\% bonus to attack.
 
-In general, $IV_A$ adds a percentage boost of
+In general, \IV{A} adds a percentage boost of
 
-\[ \frac{IV_A}{ATK} \cdot 100 \]
+\[ \frac{\IV{A}}{\mathit{ATK}} \cdot 100 \]
 
-\noindent{}to attack, and $IV_D$ lends the same (of course using DEF) to defense.
+\noindent{}to attack, and \IV{D} lends the same (of course using DEF) to defense.
 
 This might not lead to any change in actual damage, depending on
   an opponent's own attack and defense.
 We can see this null effect in an opponent-independent way: it is quite possible
-  for two different IVs to yield the exact same MHP.
-As an example, a Sigilyph (base STA 176) at level 22 has an MHP of 119 with
-  either a 15 or a 14 $IV_S$: there is literally no difference between the
+  for two different IVs to yield the exact same \MHP\@.
+As an example, a Sigilyph (base STA 176) at level 22 has an \MHP{} of 119 with
+  either a 15 or a 14 \IV{S}: there is literally no difference between the
   two values.
 In short, IVs (usually) have real effects, but (especially for more powerful species)
   the difference between 0/0/0 and 15/15/15 is often less than that due to
@@ -156,7 +156,7 @@ Attacks of longer duration allow the opponent to blunder with regard to the
 Short attacks credit damage more quickly than long ones.
 There's no general rule: fast attack selection comes down to attack type
   (both for effectiveness and STAB), the Pokémon's charged attacks,
-  and even the $\frac{P \cdot \mathit{Eff_A}}{\mathit{Eff_D}}$ of expected opponents.
+  and even the $\frac{P \cdot \mathit{Eff_\mathrm{A}}}{\mathit{Eff_\mathrm{D}}}$ of expected opponents.
 Some Pokémon can learn two fast attacks of the same type and duration,
   where one is strictly inferior to the other in terms of power and
   energy.


### PR DESCRIPTION
Hello there! This PR makes a couple of independent changes to the Pokémon GO book's LaTeX source.

The first is an addition of two lines to `pgo.tex` and fixes an error I get from xcolor when compiling. I don't think this issue is exclusive to me, though I am curious why it doesn't seem necessary on your end.

The second and more important change is adding `\mathit` to a few spots — namely all occurrences of Eff_A, Eff_D, and Eff_S in the files — where the wide math kerning hurts the appearance of the book. Below is a comparison for your convenience.

<img width="993" height="169" alt="image" src="https://github.com/user-attachments/assets/733d3ea1-181d-4196-a7b3-25c76568cf0f" />

Making the same change to remaining instances of this kind of thing would likely get a little tedious, so I'm testing the waters with a simpler case. Would you say it's worth it to keep going?